### PR TITLE
Fix worker startup status and review system readiness

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -6,9 +6,9 @@ on:
       version:
         description: Exact reviewed package version already available on PyPI
         required: true
-        default: '0.3.3'
+        default: '0.4.0'
         type: choice
-        options: ['0.3.3']
+        options: ['0.4.0']
 
 permissions:
   contents: read
@@ -55,15 +55,15 @@ jobs:
                   raise SystemExit(message)
 
           version = os.environ["RELEASE_VERSION"]
-          require(version == "0.3.3", "This workflow only publishes the reviewed 0.3.3 metadata.")
+          require(version == "0.4.0", "This workflow only publishes the reviewed 0.4.0 metadata.")
           project = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))["project"]
           require(project["name"] == "fantasy-football-manager" and project["version"] == version,
                   "The checkout package version does not match the requested version.")
           server = json.loads(Path("docs/registry/server.json").read_text(encoding="utf-8"))
           canonical = json.dumps(server, sort_keys=True, separators=(",", ":")).encode("utf-8")
           require(hashlib.sha256(canonical).hexdigest() ==
-                  "f9767dd78dd761dbbeaef833bb82d687b174808a68fe4a01ecfb40ad40ea7297",
-                  "Registry metadata differs from the reviewed 0.3.3 document.")
+                  "a20c50194cbcfabbc4910321aa028620a43633109839f796fdd39a674f8f9377",
+                  "Registry metadata differs from the reviewed 0.4.0 document.")
 
           class RejectRedirect(urllib.request.HTTPRedirectHandler):
               def redirect_request(self, request, response, code, message, headers, new_url):

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -187,7 +187,10 @@ The worker is not an operating-system service and has no automatic reboot recove
 See the [fourth draft record](FOURTH_DRAFT_ACCEPTANCE.md) for installed v0.3.1 submissions with a private orchestration launcher.
 The earlier [live draft record](LIVE_DRAFT_ACCEPTANCE.md) retains its development-runtime limits and recovery failures.
 The v0.3.3 release and draft records remain historical evidence for the browser workflow.
-The v0.4.0 HTTP release candidate still requires separate live write acceptance.
+The v0.4.0 HTTP candidate completed one authorized free-agent add/drop and a subsequent lineup exchange on 2026-09-10 UTC.
+Both transactions had matching ESPN receipts and fresh roster observations. The previous policy was restored after verification.
+Read [HTTP season acceptance](HTTP_SEASON_ACCEPTANCE.md) for this result and its limits.
+Live waiver processing, IR moves, scoring-week rollover, and an unattended season remain **Not Tested**.
 
 ## Draft entry and season handoff
 

--- a/docs/IMPLEMENTATION_CONTRACT.md
+++ b/docs/IMPLEMENTATION_CONTRACT.md
@@ -1,5 +1,9 @@
 # Implementation contract
 
+**Historical record:** This contract describes the first implementation and early browser support.
+The assignments, planned work, and capability limits below are superseded. They do not identify current tasks.
+Read [architecture](ARCHITECTURE.md) for the current design and [HTTP season acceptance](HTTP_SEASON_ACCEPTANCE.md) for verified results and remaining limits.
+
 This file coordinates the first implementation. All public examples must be synthetic.
 
 ## Shared models

--- a/docs/POLICY.md
+++ b/docs/POLICY.md
@@ -4,7 +4,11 @@ Strategy, execution permission, and hard limits are separate controls.
 The manager's execution tools remain restricted to synthetic demonstrations.
 Published v0.3.3 supports browser draft picks and one verified lineup swap per proposal.
 The unreleased v0.4.0 candidate adds HTTP lineups, acquisitions, waiver claims, drops, and IR moves through the ESPN companion.
-Trade execution remains unavailable. New HTTP write acceptance remains **Not Tested** at this documentation checkpoint.
+Trade execution remains unavailable.
+A live trial on 2026-09-10 UTC verified one automatic HTTP free-agent add/drop and a subsequent lineup exchange.
+The trial used exact user-authorized limits and restored the previous policy after verification.
+Read [HTTP season acceptance](HTTP_SEASON_ACCEPTANCE.md) for the transaction receipts and roster verification.
+Live waiver processing, IR moves, and scoring-week rollover remain **Not Tested**.
 
 | Control | Meaning |
 |---|---|

--- a/docs/SERVER.md
+++ b/docs/SERVER.md
@@ -295,7 +295,8 @@ After recovery, the archive importer can replay durable local evidence without d
 
 ## Current limits
 
-- HTTP season scheduling supports verified automatic rollover. Pending transactions can hold the original week.
+- HTTP season scheduling supports automatic rollover from verified period evidence. Fictional tests passed. Live rollover remains **Not Tested**.
+- Pending transactions can hold the original week.
 - HTTP lineups, acquisitions, drops, and IR moves require current source evidence and separate saved permissions.
 - Legacy browser lineups support one qualifying swap per proposal and require an explicit week.
 - Draft automation uses the separate draft worker. The season coordinator rejects draft entries.
@@ -307,6 +308,10 @@ After recovery, the archive importer can replay durable local evidence without d
 Read the [multi-team acceptance plan](MULTI_TEAM_ACCEPTANCE.md) before extending the evaluation.
 The v0.3.3 release and older server records remain historical evidence.
 The reviewed v0.4.0 wheel is deployed privately. Its first HTTP sweep returned five fresh observations and four current lineup analyses.
-The remaining team had incomplete tight-end coverage. No live HTTP write occurred.
+The remaining team had incomplete tight-end coverage. That initial sweep submitted no live HTTP write.
+A later authorized repair completed an automatic free-agent add/drop and a subsequent lineup exchange on 2026-09-10 UTC.
+Both transactions had matching ESPN receipts and fresh roster observations. The previous policy was restored after verification.
+A follow-up cycle found current analysis for all five teams, healthy overall status, and no duplicate submission.
+Live waiver processing, IR moves, scoring-week rollover, and an unattended season remain **Not Tested**.
 Read [HTTP season acceptance](HTTP_SEASON_ACCEPTANCE.md) for package verification and the remaining acceptance gates.
 See [validation status](VALIDATION.md) and the [HTTP source contract](ESPN_HTTP_COMPATIBILITY.md) for the evidence boundary.

--- a/docs/SYSTEM_REVIEW.md
+++ b/docs/SYSTEM_REVIEW.md
@@ -1,0 +1,117 @@
+# Systems review: 2026-09-10
+
+The review found a worker startup reporting defect, a Registry publication configuration gap, and stale acceptance descriptions.
+The source corrections passed 1,084 local tests with 22 environment-dependent skips.
+The deployed five-team HTTP coordinator was healthy before maintenance.
+Public v0.4.0 distribution and several live acceptance gates remain incomplete.
+
+## Scope and evidence
+
+The review covered the source, documentation, installed plugin, Linux services, archive, backups, GitHub, PyPI, MCP Registry, and Glama.
+The initial deployed source was commit `e70bfc0edc3320b89236f01e22d675d86baec334`.
+Operational measurements below describe the read-only observation at 21:25 UTC.
+Private receipts retain exact file hashes and deployment details. Public records omit account identifiers, credentials, hostnames, and private paths.
+
+| System | Verified result |
+|---|---|
+| Season coordinator | HTTP transport, five enabled teams, fresh observations, current lineup analysis, 835 completed cycles, and no service restart since 03:25 UTC. |
+| Lineup policy | All five teams retained automatic lineup mode. The current state admitted no lineup change. |
+| Live claims | The two earlier repair proposals remained confirmed. No unresolved HTTP proposal was present. |
+| Archive | 114,787 records, 178,543 labels, 17 runs, 2,485 receipts, and five checkpoints. The latest receipt occupied 457 bytes. |
+| Archive storage | 729,299,991 bytes. Collection continued after the earlier receipt compaction and checkpoint recovery. |
+| Daily backup | The 07:34 UTC set was complete. All eight file sizes and SHA-256 hashes matched its manifest. |
+| Backup readability | All five SQLite backups passed `quick_check`. PostgreSQL accepted the dump catalog. This review did not repeat a full restore. |
+| Session protection | The service owned the session file. File and directory permissions were `0600` and `0700`. |
+| Service status | No failed units. The season service was active. The archive, backup, and discovery services recorded successful previous runs. |
+
+These results establish an observed operating window. They do not establish an unattended season or future session validity.
+The earlier full restore and exact archive reconstruction remain documented in [archive acceptance](ARCHIVE_INCREMENTAL.md).
+
+## Corrections
+
+### Worker startup acknowledgment
+
+A standalone worker could finish its first HTTP or draft cycle before the launcher read the initial heartbeat.
+The launcher then reported `startup_pending` for valid cycle states that its acknowledgment list omitted.
+The correction recognizes the emitted HTTP outcomes and the draft `not_selected` outcome.
+It preserves exact launch identity, positive process identifiers, heartbeat freshness, and launcher-exit checks.
+An acknowledged worker can still report an unsuccessful transaction. Acknowledgment does not prove that an action succeeded.
+
+The change added 28 regression cases, including inactive states, stale heartbeats, future timestamps, and a different launch identity.
+The timeout message now describes worker startup without assuming a browser transport.
+
+### Registry publication readiness
+
+The Registry workflow still selected v0.3.3 while the source metadata declared v0.4.0.
+Its version choice, exact version guard, and reviewed metadata digest now match v0.4.0.
+Eight offline regression cases exercise the actual workflow preflight with fictional public metadata.
+The workflow still requires the exact PyPI release, distribution digests, ownership marker, reviewed Registry metadata, and an absent Registry version.
+No publication workflow was dispatched during this review.
+
+### Documentation and plugin description
+
+The policy, architecture, server guide, and plugin description now recognize the two verified automatic HTTP repair actions.
+The original degraded observation remains in the historical record.
+The first implementation contract now identifies itself as historical and links the current design and acceptance evidence.
+The personal plugin description was refreshed. Its existing SSH configuration remained byte-for-byte unchanged.
+
+### Deployment verification
+
+The corrected private wheel was installed at 21:31 UTC after a controlled service stop and five consistent SQLite backups.
+All 28 installed Python files matched the wheel. Dependencies, team policies, service files, and the coordinator manifest remained unchanged.
+Only `espn_service.py` changed runtime behavior. Other Python differences were line endings.
+The wheel SHA-256 was `565556ae268dc05ee71a1aaaaba899be41754ebc8cf1b2ca7e66eab9bfbd7564`.
+The earlier live repair remains attributed to its original artifact.
+
+The service manager had reported outdated loaded unit definitions before maintenance.
+The installed unit files were inspected before a daemon reload. The warnings cleared without a unit-file change.
+The restarted coordinator completed a five-team sweep and reported healthy analysis at 21:32 UTC.
+The archive timer resumed and committed another compact receipt. No new HTTP proposal appeared during verification.
+
+## Validation
+
+| Check | Result |
+|---|---|
+| Complete local suite | 1,084 passed, 22 skipped. |
+| Runtime and transaction controller checks | 180 passed. No live browser or ESPN transaction was required. |
+| Skipped local cases | 17 isolated browser cases, four isolated PostgreSQL cases, and one Windows symlink case. |
+| Release metadata and privacy | Passed. |
+| Local documentation links | 225 existing links resolved during the initial review. |
+| Patch formatting | `git diff --check` passed. |
+
+Earlier browser, PostgreSQL, and live acceptance results remain separate evidence.
+This local run does not replace those environment-specific checks.
+
+## Distribution and external review
+
+At 21:23 UTC, GitHub, PyPI, and MCP Registry still published v0.3.3.
+The exact PyPI and Registry v0.4.0 endpoints returned `404`.
+The repository had no open project issue or pull request before these review corrections.
+All nine checks on the initial merged commit passed.
+
+[Glama](https://glama.ai/mcp/servers/krmisystems/fantasy-football-manager) published image 0.1.2 with package 0.4.0.
+All 17 manager definitions matched the reviewed metadata after description whitespace normalization.
+Glama's September 10 assessment was A, 4.4 overall, with a tool mean of 4.6 and minimum of 4.3.
+The personal Codex plugin is installed. Official marketplace inclusion remains unverified.
+
+The [Awesome MCP submission](https://github.com/punkpeye/awesome-mcp-servers/pull/14060) passed its submission check and had no requested changes.
+Its `welcome` job runs only after a merged closure, so the skipped result is expected while the pull request remains open.
+The remaining check annotation concerns deprecated Node.js versions in upstream actions. It did not fail the submission check.
+The entry meets the current contribution requirements. Maintainers control the merge timing.
+
+## Remaining work and explicit limits
+
+| Item | State | Completion evidence |
+|---|---|---|
+| Public v0.4.0 distribution | Planned | Publish the tested artifacts. Verify GitHub downloads, PyPI installation, Registry metadata, and both MCP entry points. |
+| Live delayed waivers and FAAB | Not Tested | Observe an authorized claim through processing and reconcile ownership and budget effects. |
+| Live IR moves and activation | Not Tested | Verify a necessary, authorized move with current injury, eligibility, capacity, and lock evidence. |
+| Live scoring-week rollover | Not Tested | Observe the actual period transition and verify pending-claim protection. |
+| Unattended season | Not Tested | Retain longitudinal operating evidence across the season. |
+| External directory and marketplace acceptance | Pending external review or unverified | Obtain maintainer acceptance. Passing checks do not establish acceptance. |
+| Session renewal | Explicit operating limit | A protected valid session is required. The HTTP importer does not renew expired sessions. |
+| Trade execution | Outside the implemented scope | The project provides no trade submission adapter. |
+
+The review found no implementation `TODO`, `FIXME`, unfinished stub, or unchecked task marker in the searched source and documentation.
+That text search does not prove that all product work is complete.
+Keep the named acceptance gates open until evidence satisfies them. Do not create unnecessary roster transactions to obtain test evidence.

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -1,5 +1,7 @@
 # Validation status
 
+Read the [September 10 systems review](SYSTEM_REVIEW.md) for the latest startup correction, deployment checks, and remaining delivery gates.
+
 ## Version 0.4.0 HTTP season candidate
 
 Read [HTTP season acceptance](HTTP_SEASON_ACCEPTANCE.md) for current source tests, authenticated reads, and live transaction evidence.

--- a/plugins/fantasy-football-manager/.codex-plugin/plugin.json
+++ b/plugins/fantasy-football-manager/.codex-plugin/plugin.json
@@ -12,7 +12,7 @@
   "interface": {
     "displayName": "Fantasy Football Manager",
     "shortDescription": "Manage ESPN drafts and season transactions within saved limits.",
-    "longDescription": "The v0.4.0 release candidate adds HTTP season lineups, acquisitions, waiver claims, drops, IR moves, and optional verified week rollover. It uses a protected session file without a browser runtime. Draft operation retains the browser adapter. Saved modes and limits control each transaction. Pending waivers require ownership confirmation. This candidate is not yet published. Live HTTP write acceptance remains pending. Trade execution is unavailable.",
+    "longDescription": "The v0.4.0 release candidate adds HTTP season lineups, acquisitions, waiver claims, drops, IR moves, and optional week rollover from verified period evidence. It uses a protected session file without a browser runtime. Draft operation retains the browser adapter. Saved modes and limits control each transaction. Pending waivers require ownership confirmation. This candidate is not yet published. A live trial verified automatic free-agent add/drop and a subsequent lineup exchange under exact user-approved limits. Live waiver processing, IR moves, scoring-week rollover, and an unattended season remain Not Tested. Trade execution is unavailable.",
     "developerName": "krmisystems",
     "category": "Productivity",
     "capabilities": [

--- a/src/fantasy_football_manager/espn_service.py
+++ b/src/fantasy_football_manager/espn_service.py
@@ -664,7 +664,9 @@ class ESPNService:
                 raise ValueError(message)
             if matching and shared.get("status") in {
                 "starting", "monitoring", "monitoring_lineup", "lineup_current", "no_admissible_lineup_exchange",
-                "paused", "awaiting_review", "awaiting_verification", "draft_complete", "needs_attention"}:
+                "paused", "awaiting_review", "awaiting_verification", "draft_complete", "needs_attention",
+                "analysis_incomplete", "state_changed", "no_admissible_candidate", "confirmed", "pending_waiver",
+                "not_submitted", "not_selected", "rejected", "cancelled", "conflict"}:
                 return {"status": shared["status"], "pid": shared["pid"], "launcher_pid": process.pid,
                         "launch_id": launch_id, "startup_acknowledged": True,
                         "worker": shared, "lifetime": "independent_of_codex",
@@ -672,5 +674,5 @@ class ESPNService:
             if asyncio.get_running_loop().time() >= deadline:
                 return {"status": "startup_pending", "pid": None, "launcher_pid": process.pid,
                         "launch_id": launch_id, "startup_acknowledged": False,
-                        "lifetime": "independent_of_codex", "message": "The process started, but browser startup is not yet verified."}
+                        "lifetime": "independent_of_codex", "message": "The process started, but worker startup is not yet verified."}
             await asyncio.sleep(.1)

--- a/tests/test_espn_runtime_boundaries.py
+++ b/tests/test_espn_runtime_boundaries.py
@@ -316,8 +316,37 @@ async def test_worker_acknowledgement_uses_launch_id_and_reports_interpreter_pid
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("state", [
+    "analysis_incomplete", "state_changed", "no_admissible_candidate", "confirmed", "pending_waiver",
+    "not_submitted", "not_selected", "rejected", "cancelled", "conflict",
+])
+async def test_completed_cycle_heartbeat_acknowledges_the_running_worker(tmp_path, state):
+    service = ESPNService(tmp_path, transport="http")
+    launch_id = uuid.uuid4().hex
+    service._save_status(state, pid=20202, launch_id=launch_id)
+    result = await service._await_worker_start(SimpleNamespace(pid=10101, poll=lambda: None),
+                                              timeout=0, launch_id=launch_id)
+    assert result["startup_acknowledged"] is True
+    assert result["status"] == result["worker"]["status"] == state
+    assert result["pid"] == 20202 and result["launcher_pid"] == 10101
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", ["connected", "stopped", "stopping", "disconnected", "startup_failed", "unknown"])
+async def test_inactive_or_unknown_heartbeat_does_not_acknowledge_worker_startup(tmp_path, state):
+    service = ESPNService(tmp_path, transport="http")
+    launch_id = uuid.uuid4().hex
+    service._save_status(state, pid=20202, launch_id=launch_id)
+    result = await service._await_worker_start(SimpleNamespace(pid=10101, poll=lambda: None),
+                                              timeout=0, launch_id=launch_id)
+    assert result["startup_acknowledged"] is False and result["status"] == "startup_pending"
+    assert "worker startup" in result["message"] and "browser" not in result["message"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("state", ["monitoring", "analysis_incomplete", "confirmed", "pending_waiver", "not_selected"])
 @pytest.mark.parametrize("evidence", ["other_launch", "stale", "future"])
-async def test_other_or_stale_heartbeat_cannot_acknowledge_new_worker(tmp_path, evidence):
+async def test_other_or_stale_heartbeat_cannot_acknowledge_new_worker(tmp_path, evidence, state):
     service = ESPNService(tmp_path)
     launch_id = uuid.uuid4().hex
     timestamp = datetime.now(timezone.utc)
@@ -325,7 +354,7 @@ async def test_other_or_stale_heartbeat_cannot_acknowledge_new_worker(tmp_path, 
         timestamp -= timedelta(seconds=120)
     elif evidence == "future":
         timestamp += timedelta(seconds=120)
-    service._save_status("monitoring", pid=10101, launch_id="other-launch" if evidence == "other_launch" else launch_id,
+    service._save_status(state, pid=10101, launch_id="other-launch" if evidence == "other_launch" else launch_id,
                          observed_at=timestamp.isoformat())
     result = await service._await_worker_start(SimpleNamespace(pid=10101, poll=lambda: None),
                                               timeout=0, launch_id=launch_id)

--- a/tests/test_release_validation.py
+++ b/tests/test_release_validation.py
@@ -1,8 +1,15 @@
 """Test release version consistency and privacy checks with temporary fixtures."""
 
+import ast
 import importlib.util
+import io
 import json
 from pathlib import Path
+import re
+import textwrap
+import tomllib
+import urllib.error
+import urllib.request
 
 import pytest
 
@@ -124,3 +131,114 @@ def test_registry_namespace_version_and_transport_checks_remain_active(release_s
     write_json(release_source, "docs/registry/server.json", value)
     errors, _ = validator.validate(release_source)
     assert any(expected in error for error in errors)
+
+
+def test_registry_dispatch_version_matches_current_package():
+    workflow = (REPO / ".github/workflows/registry.yml").read_text(encoding="utf-8")
+    version = tomllib.loads((REPO / "pyproject.toml").read_text(encoding="utf-8"))["project"]["version"]
+    inputs = workflow.split("permissions:", 1)[0]
+    defaults = re.findall(r"^        default: (.+)$", inputs, re.MULTILINE)
+    choices = re.findall(r"^        options: (.+)$", inputs, re.MULTILINE)
+    assert len(defaults) == len(choices) == 1
+    assert ast.literal_eval(defaults[0]) == version
+    assert ast.literal_eval(choices[0]) == [version]
+
+
+@pytest.fixture
+def registry_preflight(tmp_path, monkeypatch):
+    """Run the actual workflow preflight with fictional public metadata only."""
+    workflow = (REPO / ".github/workflows/registry.yml").read_text(encoding="utf-8")
+    marker = "          uv run --no-project --python 3.12 python - <<'PY'\n"
+    assert workflow.count(marker) == 1
+    source, terminator, _ = workflow.split(marker, 1)[1].partition("\n          PY\n")
+    assert terminator
+    code = compile(textwrap.dedent(source), "registry-workflow-preflight", "exec")
+    for name in ("pyproject.toml", "docs/registry/server.json"):
+        write(tmp_path, name, (REPO / name).read_text(encoding="utf-8"))
+    version = tomllib.loads((tmp_path / "pyproject.toml").read_text(encoding="utf-8"))["project"]["version"]
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("RELEASE_VERSION", version)
+    pypi_url = f"https://pypi.org/pypi/fantasy-football-manager/{version}/json"
+    registry_url = ("https://registry.modelcontextprotocol.io/v0.1/servers/"
+                    "io.github.krmisystems%2Ffantasy-football-manager/versions/" + version)
+    state = {
+        "pypi_status": 200,
+        "registry_status": 404,
+        "requested": [],
+        "published": {
+            "info": {"name": validator.NAME, "version": version,
+                     "description": f"mcp-name: io.github.krmisystems/{validator.NAME}"},
+            "urls": [
+                {"filename": f"fantasy_football_manager-{version}-py3-none-any.whl",
+                 "packagetype": "bdist_wheel", "yanked": False, "digests": {"sha256": "0" * 64}},
+                {"filename": f"fantasy_football_manager-{version}.tar.gz",
+                 "packagetype": "sdist", "yanked": False, "digests": {"sha256": "1" * 64}},
+            ],
+        },
+    }
+
+    class FakeResponse(io.BytesIO):
+        def geturl(self):
+            return pypi_url
+
+    class FakeOpener:
+        def open(self, request, timeout):
+            url = request.full_url
+            assert url in (pypi_url, registry_url), "Unexpected preflight endpoint"
+            state["requested"].append(url)
+            status = state["pypi_status" if url == pypi_url else "registry_status"]
+            if status != 200:
+                raise urllib.error.HTTPError(url, status, "Fictional response", {}, None)
+            return FakeResponse(json.dumps(state["published"]).encode("utf-8"))
+
+    monkeypatch.setattr(urllib.request, "build_opener", lambda *handlers: FakeOpener())
+    state["run"] = lambda: exec(code, {"__name__": "__main__"})
+    state["metadata_path"] = tmp_path / "docs/registry/server.json"
+    state["expected_requests"] = [pypi_url, registry_url]
+    return state
+
+
+def test_current_registry_preflight_accepts_reviewed_metadata(registry_preflight):
+    registry_preflight["run"]()
+    assert registry_preflight["requested"] == registry_preflight["expected_requests"]
+
+
+def test_registry_preflight_rejects_unreviewed_metadata_before_network(registry_preflight):
+    path = registry_preflight["metadata_path"]
+    metadata = json.loads(path.read_text(encoding="utf-8"))
+    metadata["description"] = "Unreviewed description."
+    path.write_text(json.dumps(metadata), encoding="utf-8")
+    with pytest.raises(SystemExit, match="Registry metadata differs"):
+        registry_preflight["run"]()
+    assert registry_preflight["requested"] == []
+
+
+@pytest.mark.parametrize("scenario, expected", [
+    ("wrong_version", "exact package version"),
+    ("missing_marker", "ownership marker"),
+    ("yanked_wheel", "missing, yanked"),
+    ("existing_registry_version", "Registry version already exists"),
+])
+def test_registry_preflight_preserves_publication_gates(registry_preflight, scenario, expected):
+    published = registry_preflight["published"]
+    if scenario == "wrong_version":
+        published["info"]["version"] = "0.0.0"
+    elif scenario == "missing_marker":
+        published["info"]["description"] = "Fictional package without an ownership marker."
+    elif scenario == "yanked_wheel":
+        published["urls"][0]["yanked"] = True
+    elif scenario == "existing_registry_version":
+        registry_preflight["registry_status"] = 200
+    with pytest.raises(SystemExit, match=expected):
+        registry_preflight["run"]()
+    expected_requests = registry_preflight["expected_requests"]
+    assert registry_preflight["requested"] == (
+        expected_requests if scenario == "existing_registry_version" else expected_requests[:1])
+
+
+def test_registry_preflight_stops_when_public_package_is_absent(registry_preflight):
+    registry_preflight["pypi_status"] = 404
+    with pytest.raises(urllib.error.HTTPError) as error:
+        registry_preflight["run"]()
+    assert error.value.code == 404
+    assert registry_preflight["requested"] == registry_preflight["expected_requests"][:1]


### PR DESCRIPTION
A standalone worker could finish its first HTTP or draft cycle before the launcher read its initial heartbeat. Valid cycle outcomes then appeared as `startup_pending`. Recognize those outcomes while preserving launch identity, heartbeat freshness, positive PID, and process-exit checks.

Align the Registry publication workflow with the reviewed 0.4.0 metadata. Preserve its public-package, ownership, digest, and duplicate-version checks. Correct stale HTTP acceptance descriptions and record the systems review, deployment verification, and remaining live and public-release gates.

Validation: 1,084 local tests passed with 22 environment-dependent skips. Added 28 startup regression cases and eight Registry preflight cases. Release/privacy validation and `git diff --check` passed. The private server update matched all 28 Python files to the reviewed wheel and returned to healthy five-team operation. Dependencies, policies, service files, and HTTP proposal counts remained unchanged. No public package or Registry publication was dispatched.
