### PR TITLE
Check GitHub and Glama state after project updates

### DIFF
--- a/.github/workflows/distribution-status.yml
+++ b/.github/workflows/distribution-status.yml
@@ -1,0 +1,98 @@
+name: Distribution status
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_run:
+    workflows: ['Test and package']
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: '17 7 * * *'
+
+permissions:
+  contents: read
+  actions: read
+  checks: read
+
+concurrency:
+  group: distribution-status-main
+  cancel-in-progress: false
+
+jobs:
+  report:
+    name: Collect distribution evidence
+    if: >-
+      github.repository == 'krmisystems/fantasy-football-manager' &&
+      (github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main') &&
+      (github.event_name != 'workflow_run' ||
+       (github.event.workflow_run.head_repository.full_name == github.repository &&
+        github.event.workflow_run.head_branch == 'main' &&
+        github.event.workflow_run.event != 'pull_request'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out trusted main
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: refs/heads/main
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          python-version: '3.11'
+          enable-cache: false
+      - name: Check public distribution state
+        id: collect
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          uv run --no-project --python 3.11 python scripts/check_distribution_status.py
+          --output .local-state/distribution-status/report.json
+          --summary .local-state/distribution-status/summary.md
+      - name: Show evidence and collection status
+        if: ${{ always() }}
+        env:
+          COLLECTOR_OUTCOME: ${{ steps.collect.outcome }}
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          directory = Path('.local-state/distribution-status')
+          directory.mkdir(parents=True, exist_ok=True)
+          report = directory / 'report.json'
+          summary = directory / 'summary.md'
+          outcome = os.environ.get('COLLECTOR_OUTCOME', 'unknown')
+          if not report.is_file():
+              report.write_text(json.dumps({
+                  'collection_status': outcome,
+                  'distribution_status': 'unknown',
+                  'reason': 'The checker did not produce a JSON report.',
+              }, indent=2) + '\n', encoding='utf-8')
+          if not summary.is_file():
+              summary.write_text(
+                  '**Unknown:** The checker did not produce a status summary. '
+                  'Review the workflow logs.\n', encoding='utf-8')
+          with Path(os.environ['GITHUB_STEP_SUMMARY']).open('a', encoding='utf-8') as stream:
+              stream.write('## Distribution evidence\n\n')
+              stream.write(f'Checker execution: **{outcome}**.\n\n')
+              stream.write('A successful workflow means the check ran. '
+                           'It does not mean every external service is current.\n\n')
+              stream.write(summary.read_text(encoding='utf-8'))
+          PY
+      - name: Save status reports
+        if: ${{ always() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: distribution-status-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            .local-state/distribution-status/report.json
+            .local-state/distribution-status/summary.md
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# Repository instructions
+
+These instructions apply to this repository and its subdirectories.
+
+## Technical writing
+
+- Use the `write-ste-technical-content` skill for technical writing.
+- Use short sentences, active voice, and consistent terms.
+- Separate verified results, estimates, planned work, and untested behavior.
+- Preserve exact commands, paths, identifiers, and protocol fields.
+- Do not claim formal ASD-STE100 conformity without a formal review.
+
+## Completion checks
+
+After repository updates, complete these checks before the final handoff:
+
+1. Run the tests that apply to the change.
+2. Run `uv run python scripts/validate_release.py` for release metadata and privacy checks.
+3. Run the distribution checker:
+
+   ```text
+   python scripts/check_distribution_status.py --output .local-state/distribution-status/report.json --summary .local-state/distribution-status/summary.md
+   ```
+
+4. Read the JSON report and Markdown summary.
+5. Report each pending, stale, failed, or unknown local and external state.
+6. After an authorized push, merge, or publication, repeat the distribution check against the new remote state.
+
+A successful checker process does not prove that all distribution channels are current.
+Do not mark distribution verification complete while required evidence remains pending or unknown.
+Distinguish completed code changes from external publication or synchronization that remains incomplete.
+Use `--strict` when the calling process must fail for any pending, stale, failed, or unknown check, including local state.
+The current checker cannot attest to the hosted Glama build commit, so strict mode cannot report all checks current.
+Report this evidence limit instead of weakening the check.
+
+The checker reads public service data and optional authenticated GitHub data.
+Its execution does not authorize publication, a Glama sync, configuration changes, or messages to maintainers.
+Do not perform these actions solely to make a status check pass.
+Use existing user authorization when an external action is part of the task.
+These instructions and the GitHub Actions workflow apply only to this repository.
+They do not configure global Codex settings or native plugin hooks.
+
+## Evidence and privacy
+
+- Keep private reports under the ignored `.local-state/` directory.
+- Do not commit credentials, personal team data, server names, or private paths.
+- Never log tokens or session values.
+- Use fictional fixtures for public tests and screenshots.
+- Preserve separate version labels for the Python package and the Glama image.
+- Do not infer a hosted build commit from matching README content or version text.
+- Do not claim a full tool schema comparison when only names and descriptions were checked.
+
+See [Distribution status](docs/DISTRIBUTION_STATUS.md) for the check scope and operating limits.

--- a/README.md
+++ b/README.md
@@ -295,5 +295,7 @@ Browser and PostgreSQL cases require their explicit test settings. Use the [comp
 Release packaging waits for the requested commit's Windows, Ubuntu, Chrome, and PostgreSQL gates.
 See [architecture](https://github.com/krmisystems/fantasy-football-manager/blob/main/docs/ARCHITECTURE.md), [policy](https://github.com/krmisystems/fantasy-football-manager/blob/main/docs/POLICY.md), and [release instructions](https://github.com/krmisystems/fantasy-football-manager/blob/main/docs/RELEASING.md).
 The [discovery measurement plan](https://github.com/krmisystems/fantasy-football-manager/blob/main/docs/DISCOVERY_MEASUREMENT.md) separates publication checks from observed discovery results.
+The repository's [distribution check](docs/DISTRIBUTION_STATUS.md) reports GitHub and Glama state after updates and each day.
+It records release gaps and unknown build evidence without publishing or requesting a rebuild.
 
 License: [MIT](https://github.com/krmisystems/fantasy-football-manager/blob/main/LICENSE). Copyright 2026 krmisystems.

--- a/docs/DISTRIBUTION_STATUS.md
+++ b/docs/DISTRIBUTION_STATUS.md
@@ -1,0 +1,92 @@
+# Distribution status
+
+The checker compares this checkout with public distribution evidence.
+It writes a JSON report and a Markdown summary.
+It does not publish packages, refresh Glama, or call a Codex model.
+
+Run this command from the repository root with Python 3.11 or later:
+
+```text
+python scripts/check_distribution_status.py --output .local-state/distribution-status/report.json --summary .local-state/distribution-status/summary.md
+```
+
+The script uses the Python standard library.
+An optional `GH_TOKEN` supplies read access to GitHub metadata.
+No PyPI, Glama, or model API key is required.
+Do not place tokens in command arguments or reports.
+
+The default exit code permits a completed check with pending or unknown states.
+Read the report before declaring distribution complete.
+Add `--strict` to return exit code 1 for pending, stale, failed, or unknown checks, including local checkout state.
+Collection failure returns exit code 2.
+
+## Evidence checked
+
+| Surface | Comparison | Limit |
+| --- | --- | --- |
+| Checkout | Local commit and worktree state against GitHub `main` | Unpushed or uncommitted work does not prove a remote update. |
+| GitHub CI | Latest `Test and package` run for the target commit | This distribution workflow does not count its own run as release validation. |
+| Releases | Source version, GitHub release tag, and public PyPI version | Source changes do not automatically create a release. |
+| Glama indexed source | Public source-tree commit against GitHub `main` | An indexed commit identifies the listing's source. It does not attest to the hosted runtime build. |
+| Glama tools | Manager tool names and normalized descriptions, extracted from source with Python's AST parser | The current manager defines 17 tools. The five portfolio tools and ESPN tools belong to separate servers and are excluded. |
+| Glama build information | Publicly exposed version and build evidence | A hidden build commit remains unknown. Python and image versions are separate values. |
+
+Unavailable or ambiguous evidence remains unknown.
+A pending external update remains pending until a later check confirms it.
+A matching indexed commit or version cannot establish an unpublished runtime build commit.
+Tool metadata comparison does not include input schemas, output schemas, or annotations.
+
+The checker cannot verify the runtime build commit from the public pages it reads.
+Thus `glama_build` remains unknown, and `--strict` currently returns a nonzero result even when every other check is current.
+An owner-side build verification feature is not implemented.
+An owner can review Glama Admin separately, but this checker does not import that evidence.
+
+The 0.4.0 source candidate is newer than the published 0.3.3 package at this implementation's review.
+That version difference is an intentional pending publication state, not evidence of a failed release.
+Use the latest report for current versions.
+
+Public evidence comes from [GitHub commit metadata](https://api.github.com/repos/krmisystems/fantasy-football-manager/commits/main),
+[PyPI package metadata](https://pypi.org/pypi/fantasy-football-manager/json),
+and Glama's [indexed source](https://glama.ai/mcp/servers/krmisystems/fantasy-football-manager/tree),
+[tool listing](https://glama.ai/mcp/servers/krmisystems/fantasy-football-manager/schema),
+and [overview](https://glama.ai/mcp/servers/krmisystems/fantasy-football-manager).
+The Glama reader decodes observed page data without executing JavaScript.
+That page format is undocumented. A format change can make a check unknown.
+
+## Automatic reports
+
+The [Distribution status workflow](../.github/workflows/distribution-status.yml) checks the canonical repository:
+
+- After a push to `main`.
+- After a published GitHub release.
+- After `Test and package` completes on the repository's `main` branch.
+- On a manual run selected from `main`.
+- Daily at 07:17 UTC.
+
+The workflow always checks out trusted `main`.
+It does not execute a pull request checkout or download artifacts from an untrusted run.
+Its GitHub permissions are limited to read access for contents, actions, and checks.
+Concurrent runs wait, and each job has a ten-minute timeout.
+
+The workflow attaches its summary to the job and saves both reports as an artifact for 30 days.
+If collection fails before a report exists, the artifact records that failure as unknown distribution evidence.
+A green workflow means the checker completed successfully. It does not mean every external state is current.
+
+GitHub can delay scheduled jobs. Scheduled and workflow-completion triggers require the workflow file on the default branch.
+See [GitHub's event documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows).
+
+This workflow only observes Glama.
+It does not configure a webhook or request a sync or build.
+The daily report can detect a later external update, but it does not cause that update.
+This is a repository GitHub Actions hook plus an `AGENTS.md` completion instruction.
+It does not change global Codex settings, native Codex hooks, or plugin hooks.
+
+## Completion gate
+
+Follow the [repository instructions](../AGENTS.md) after each update.
+Run relevant tests and the release privacy validator.
+Inspect the distribution report after the authorized remote update.
+Report remaining external work separately from completed implementation work.
+
+Publication and listing changes require authorization from the current task or earlier instructions.
+A failed status comparison does not supply that authorization.

--- a/scripts/check_distribution_status.py
+++ b/scripts/check_distribution_status.py
@@ -1,0 +1,328 @@
+"""Check this project's public distribution state. Never publish or trigger builds."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import base64
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+from http.client import HTTPException
+import inspect
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import tomllib
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode, urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+REPO = "krmisystems/fantasy-football-manager"
+GITHUB = "https://api.github.com/repos/" + REPO
+GLAMA = "https://glama.ai/mcp/servers/" + REPO
+ROOT = Path(__file__).resolve().parents[1]
+MAX_BYTES = 6_000_000
+SHA = re.compile(r"[0-9a-f]{40}")
+ROUTE = "routes/_public/mcp/servers/~namespace/~slug/_pages/"
+
+
+class CheckError(ValueError):
+    """A bounded public check could not establish its result."""
+
+
+class NoRedirect(HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        raise CheckError("redirect_refused")
+
+
+def fetch(url, *, token=None):
+    """Read fixed public hosts. Send an optional token only to GitHub."""
+    parsed = urlsplit(url)
+    if parsed.scheme != "https" or parsed.netloc not in {"api.github.com", "glama.ai", "pypi.org"}:
+        raise CheckError("unexpected_endpoint")
+    headers = {"User-Agent": "fantasy-football-manager-distribution-check", "Cache-Control": "no-cache"}
+    if parsed.netloc == "api.github.com":
+        headers.update(Accept="application/vnd.github+json")
+        headers["X-GitHub-Api-Version"] = "2022-11-28"
+        if token:
+            headers["Authorization"] = "Bearer " + token
+    try:
+        with build_opener(NoRedirect()).open(Request(url, headers=headers), timeout=15) as response:
+            body = response.read(MAX_BYTES + 1)
+            if len(body) > MAX_BYTES:
+                raise CheckError("response_too_large")
+            return body.decode("utf-8")
+    except HTTPError as exc:
+        raise CheckError("http_" + str(exc.code)) from None
+    except (URLError, TimeoutError, OSError, UnicodeError, HTTPException):
+        raise CheckError("request_failed") from None
+
+
+def decode_hydration(html):
+    """Decode Glama's observed public JSON format without executing JavaScript."""
+    chunks = re.findall(r'window\.__reactRouterContext\.streamController\.enqueue\(("(?:\\.|[^"\\])*")\)', html)
+    if len(chunks) != 1:
+        raise CheckError("public_page_format_changed")
+    try:
+        nodes = json.loads(json.loads(chunks[0]))
+        if not isinstance(nodes, list) or not 0 < len(nodes) <= 100_000:
+            raise CheckError("invalid_public_nodes")
+        memo, active = {}, set()
+
+        def resolve(index, depth=0):
+            if type(index) is not int or depth > 100:
+                raise CheckError("invalid_public_reference")
+            if index == -5:
+                return None
+            if not 0 <= index < len(nodes) or index in active:
+                raise CheckError("invalid_public_reference")
+            if index in memo:
+                return memo[index]
+            active.add(index)
+            value = nodes[index]
+            if isinstance(value, dict):
+                result = {}
+                for key, item in value.items():
+                    if not re.fullmatch(r"_\d+", key):
+                        raise CheckError("invalid_public_key")
+                    name = resolve(int(key[1:]), depth + 1)
+                    if not isinstance(name, str) or name in result:
+                        raise CheckError("invalid_public_key")
+                    result[name] = resolve(item, depth + 1)
+            elif isinstance(value, list):
+                result = [resolve(item, depth + 1) for item in value]
+            else:
+                result = value
+            active.remove(index)
+            memo[index] = result
+            return result
+
+        return resolve(0)
+    except (ValueError, TypeError, KeyError, RecursionError):
+        raise CheckError("public_page_format_changed") from None
+
+
+def route(data, suffix):
+    value = data.get("loaderData", {}).get(ROUTE + suffix)
+    if not isinstance(value, dict):
+        raise CheckError("public_page_format_changed")
+    return value
+
+
+def source_tools(source):
+    """Read tool names and docstrings from source without importing the manager."""
+    result = {}
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for decorator in node.decorator_list:
+            if (isinstance(decorator, ast.Call) and isinstance(decorator.func, ast.Attribute)
+                    and isinstance(decorator.func.value, ast.Name) and decorator.func.value.id == "server"
+                    and decorator.func.attr == "tool"):
+                name = node.name
+                for keyword in decorator.keywords:
+                    if keyword.arg == "name":
+                        name = ast.literal_eval(keyword.value)
+                if not isinstance(name, str) or name in result:
+                    raise CheckError("invalid_source_tool_names")
+                result[name] = inspect.cleandoc(ast.get_docstring(node, clean=False) or "")
+    if not result:
+        raise CheckError("no_source_tools")
+    return result
+
+
+def compare_tools(expected, tools):
+    if not isinstance(tools, list) or not tools:
+        raise CheckError("invalid_public_tools")
+    actual = {}
+    for tool in tools:
+        if not isinstance(tool, dict) or not isinstance(tool.get("name"), str) or not isinstance(tool.get("description"), str):
+            raise CheckError("invalid_public_tools")
+        if tool["name"] in actual:
+            raise CheckError("duplicate_public_tools")
+        actual[tool["name"]] = inspect.cleandoc(tool["description"])
+    changed = sorted(name for name in expected.keys() & actual.keys() if expected[name] != actual[name])
+    return {"status": "current" if expected == actual else "stale", "expected_count": len(expected),
+            "public_count": len(actual), "missing": sorted(expected.keys() - actual.keys()),
+            "unexpected": sorted(actual.keys() - expected.keys()), "changed_descriptions": changed,
+            "scope": "Manager tool names and descriptions only. Schemas, ESPN tools, and portfolio tools are not compared."}
+
+
+def ci_status(data, head):
+    if not isinstance(data, dict) or not isinstance(data.get("workflow_runs"), list):
+        raise CheckError("invalid_ci_response")
+    if any(not isinstance(run, dict) or type(run.get("id")) is not int for run in data["workflow_runs"]):
+        raise CheckError("invalid_ci_response")
+    runs = [run for run in data["workflow_runs"] if run.get("head_sha") == head
+            and run.get("head_branch") == "main" and run.get("event") in {"push", "workflow_dispatch"}]
+    if not runs:
+        return {"status": "pending", "reason": "No main CI run is available for this commit."}
+    run = max(runs, key=lambda item: item["id"])
+    conclusion = run.get("conclusion")
+    state = "pending" if run.get("status") != "completed" else ("current" if conclusion == "success" else "failed")
+    return {"status": state, "run_id": run["id"], "conclusion": conclusion, "url": run.get("html_url")}
+
+
+def git_value(*args):
+    result = subprocess.run(["git", *args], cwd=ROOT, capture_output=True, text=True, timeout=10)
+    if result.returncode:
+        raise CheckError("local_git_unavailable")
+    return result.stdout.strip()
+
+
+def content(value):
+    if value.get("encoding") != "base64" or not isinstance(value.get("content"), str):
+        raise CheckError("invalid_source_content")
+    return base64.b64decode(value["content"]).decode("utf-8")
+
+
+def outcome(function):
+    try:
+        return function()
+    except (CheckError, ValueError, TypeError, KeyError, AttributeError, RecursionError, SyntaxError, subprocess.SubprocessError):
+        return {"status": "unknown", "reason": "The response could not establish this check. Retry or inspect the linked service."}
+
+
+def collect(*, reader=fetch, token=None):
+    def get(url):
+        return reader(url, token=token)
+
+    def get_json(url):
+        return json.loads(get(url))
+
+    main = get_json(GITHUB + "/commits/main")
+    if not isinstance(main, dict):
+        raise CheckError("invalid_github_commit")
+    head = main.get("sha")
+    if not isinstance(head, str) or not SHA.fullmatch(head):
+        raise CheckError("invalid_github_commit")
+    urls = {
+        "source": GITHUB + "/contents/pyproject.toml?" + urlencode({"ref": head}),
+        "tools": GITHUB + "/contents/src/fantasy_football_manager/mcp_server.py?" + urlencode({"ref": head}),
+        "ci": GITHUB + "/actions/workflows/ci.yml/runs?" + urlencode({"head_sha": head, "branch": "main", "per_page": 20}),
+        "releases": GITHUB + "/releases?per_page=30",
+        "pypi": "https://pypi.org/pypi/fantasy-football-manager/json",
+        "tree": GLAMA + "/tree", "schema": GLAMA + "/schema", "overview": GLAMA,
+    }
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        futures = {name: pool.submit(get, url) for name, url in urls.items()}
+        responses = {}
+        for name, future in futures.items():
+            try:
+                responses[name] = future.result()
+            except (CheckError, ValueError, TypeError, OSError):
+                responses[name] = None
+
+    def data(name):
+        return json.loads(responses[name])
+
+    def source_version():
+        project = tomllib.loads(content(data("source")))["project"]
+        value = project["version"]
+        if (project.get("name") != "fantasy-football-manager" or not isinstance(value, str)
+                or not re.fullmatch(r"[0-9][A-Za-z0-9.!+_-]{0,99}", value)):
+            raise CheckError("invalid_source_version")
+        return {"status": "current", "version": value}
+
+    source = outcome(source_version)
+    version = source.get("version")
+
+    def local():
+        local_head = git_value("rev-parse", "HEAD")
+        dirty = bool(git_value("status", "--porcelain"))
+        return {"status": "current" if local_head == head and not dirty else "pending", "head": local_head,
+                "uncommitted_changes": dirty, "matches_main": local_head == head}
+
+    def releases():
+        published = [item for item in data("releases") if not item.get("draft")]
+        if not published:
+            return {"status": "pending", "reason": "No GitHub release is published."}
+        latest = max(published, key=lambda item: item.get("published_at") or "")
+        return {"status": "unknown" if version is None else ("current" if latest["tag_name"].removeprefix("v") == version else "pending"),
+                "tag": latest["tag_name"], "prerelease": latest.get("prerelease"), "url": latest.get("html_url"),
+                "scope": "Version comparison only. A tag is not a build attestation for current main."}
+
+    def pypi():
+        info = data("pypi")["info"]
+        if info.get("name") != "fantasy-football-manager":
+            raise CheckError("wrong_package")
+        return {"status": "unknown" if version is None else ("current" if info["version"] == version else "pending"),
+                "version": info["version"], "url": "https://pypi.org/project/fantasy-football-manager/",
+                "scope": "Version comparison only. Unreleased source can intentionally be newer."}
+
+    def index():
+        tree = route(decode_hydration(responses["tree"]), "_explorer/tree/_index/_route")
+        indexed = tree["member"]["commit"]["sha"]
+        if not isinstance(indexed, str) or not SHA.fullmatch(indexed):
+            raise CheckError("invalid_glama_commit")
+        return {"status": "current" if indexed == head else "stale", "indexed_commit": indexed,
+                "expected_commit": head, "url": GLAMA + "/tree", "scope": "Indexed repository source, not the hosted build."}
+
+    def schema():
+        public = route(decode_hydration(responses["schema"]), "schema/_route")["schema"]
+        return compare_tools(source_tools(content(data("tools"))), public["tools"])
+
+    def listing():
+        public = decode_hydration(responses["overview"])
+        server = route(public, "_index/_route")["mcpServer"]
+        latest = server["repository"].get("latestRelease") or {}
+        return {"status": "observed", "url": GLAMA, "updated_at": server.get("updatedAt"),
+                "image_release": latest.get("version"), "scope": "Glama image versions differ from Python package versions."}
+
+    checks = {"local_checkout": outcome(local), "github_main": {"status": "current", "commit": head,
+              "url": "https://github.com/" + REPO + "/commit/" + head}, "source_package": source,
+              "github_ci": outcome(lambda: ci_status(data("ci"), head)), "github_release": outcome(releases),
+              "pypi_release": outcome(pypi), "glama_index": outcome(index), "glama_tools": outcome(schema),
+              "glama_listing": outcome(listing), "glama_build": {"status": "unknown",
+              "reason": "The checked public pages do not attest the deployed build commit. Verify it in Glama Admin."}}
+    issues = [name for name, value in checks.items() if value["status"] not in {"current", "observed"}]
+    return {"checked_at": datetime.now(timezone.utc).isoformat(), "repository": REPO,
+            "status": "attention" if issues else "current", "attention": issues, "checks": checks,
+            "read_only": True, "model_calls": 0, "remote_writes": 0,
+            "method": "GitHub and PyPI public APIs; observed Glama public JSON hydration without script execution.",
+            "limits": "Glama hydration is undocumented. Format changes report unknown. No sync, build, publication, or score change is requested."}
+
+
+def markdown(report):
+    lines = ["# FF distribution status", "", "Checked: " + report["checked_at"], "",
+             "Overall: **" + report["status"] + "**. A successful check run does not mean every service is current.", "",
+             "| Check | State | Evidence |", "|---|---|---|"]
+    for name, value in report.get("checks", {}).items():
+        details = {key: item for key, item in value.items() if key not in {"status", "url"}}
+        # Remote values are text only. Escape table and HTML syntax in the summary.
+        text = json.dumps(details, ensure_ascii=True).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        text = text.replace("|", "&#124;").replace("`", "&#96;").replace("\n", " ")
+        lines.append(f"| {name} | {value['status']} | {text} |")
+    lines += ["", "No remote changes or model calls occurred.", "", report.get("limits", "Check collection failed."), ""]
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output", type=Path, default=ROOT / ".local-state/distribution-status/report.json")
+    parser.add_argument("--summary", type=Path, default=ROOT / ".local-state/distribution-status/summary.md")
+    parser.add_argument("--strict", action="store_true", help="Exit 1 for pending, stale, failed, or unknown checks.")
+    args = parser.parse_args()
+    failed = False
+    try:
+        report = collect(token=os.environ.get("GH_TOKEN"))
+    except (CheckError, ValueError, TypeError, KeyError, OSError):
+        failed = True
+        report = {"checked_at": datetime.now(timezone.utc).isoformat(), "repository": REPO,
+                  "status": "unknown", "checks": {"github_main": {"status": "unknown", "reason": "Could not read GitHub main."}},
+                  "read_only": True, "model_calls": 0, "remote_writes": 0}
+    for path, text in [(args.output, json.dumps(report, indent=2) + "\n"), (args.summary, markdown(report))]:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = path.with_suffix(path.suffix + ".tmp")
+        temporary.write_text(text, encoding="utf-8")
+        temporary.replace(path)
+    print(json.dumps({"status": report["status"], "checks": {name: value["status"] for name, value in report["checks"].items()}}))
+    if os.environ.get("GITHUB_ACTIONS") == "true" and report["status"] != "current":
+        print("::warning title=FF distribution needs review::One or more checks are pending, stale, failed, or unknown. Read the job summary and report artifact.")
+    return 2 if failed else (1 if args.strict and report["status"] != "current" else 0)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_distribution_status.py
+++ b/tests/test_distribution_status.py
@@ -1,0 +1,419 @@
+"""Verify public distribution checks with fictional responses and no network calls."""
+
+import base64
+from copy import deepcopy
+from http.client import BadStatusLine, IncompleteRead
+import importlib.util
+import json
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.parse import parse_qs, urlsplit
+from urllib.request import Request
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location("distribution_status", ROOT / "scripts/check_distribution_status.py")
+distribution = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(distribution)
+HEAD = "a" * 40
+OLD_HEAD = "b" * 40
+VERSION = "0.0.7"
+SECRET = "fictional-private-token"
+AT = "2026-08-20T08:00:00Z"
+
+
+@pytest.fixture(autouse=True)
+def no_external_processes_or_network(monkeypatch):
+    monkeypatch.delenv("GITHUB_ACTIONS", raising=False)
+    def forbidden(*args, **kwargs):
+        raise AssertionError("This test must not use the network or an external process.")
+    monkeypatch.setattr(distribution, "build_opener", forbidden)
+    monkeypatch.setattr(distribution.subprocess, "run", forbidden)
+
+
+def hydration_nodes(nodes):
+    return "<script>window.__reactRouterContext.streamController.enqueue(" + json.dumps(json.dumps(nodes)) + ")</script>"
+
+
+def hydration(value):
+    nodes = []
+    def encode(item):
+        index = len(nodes)
+        nodes.append(None)
+        if isinstance(item, dict):
+            encoded = {"_" + str(encode(key)): encode(value) for key, value in item.items()}
+        elif isinstance(item, list):
+            encoded = [encode(value) for value in item]
+        else:
+            encoded = item
+        nodes[index] = encoded
+        return index
+    assert encode(value) == 0
+    return hydration_nodes(nodes)
+
+
+def route_page(suffix, value):
+    return hydration({"loaderData": {distribution.ROUTE + suffix: value}})
+
+
+def encoded_content(text):
+    return {"encoding": "base64", "content": base64.b64encode(text.encode()).decode()}
+
+
+def manager_source():
+    return "\n".join(f'@server.tool()\ndef manager_tool_{i}():\n    """Read fictional manager data {i}."""\n    return {{}}\n'
+                     for i in range(17))
+
+
+def ci_run(*, head=HEAD, run_id=10, status="completed", conclusion="success", branch="main", event="push"):
+    return {"id": run_id, "head_sha": head, "head_branch": branch, "event": event,
+            "status": status, "conclusion": conclusion, "html_url": "https://github.com/fictional/project/actions/runs/10"}
+
+
+class PublicReader:
+    def __init__(self):
+        self.calls = []
+        self.failures = {}
+        self.responses = {
+            "main": {"sha": HEAD},
+            "source": encoded_content('[project]\nname="fantasy-football-manager"\nversion="' + VERSION + '"\n'),
+            "tools": encoded_content(manager_source()),
+            "ci": {"workflow_runs": [ci_run()]},
+            "releases": [{"draft": False, "prerelease": False, "tag_name": "v" + VERSION, "published_at": AT,
+                          "html_url": "https://github.com/fictional/project/releases/tag/v" + VERSION}],
+            "pypi": {"info": {"name": "fantasy-football-manager", "version": VERSION}},
+            "tree": route_page("_explorer/tree/_index/_route", {"member": {"commit": {"sha": HEAD}}}),
+            "schema": route_page("schema/_route", {"schema": {"tools": [
+                {"name": f"manager_tool_{i}", "description": f"Read fictional manager data {i}."} for i in range(17)]}}),
+            "overview": route_page("_index/_route", {"mcpServer": {"updatedAt": AT,
+                "repository": {"latestRelease": {"version": "0.1.2"}}, "latestRelease": {"version": "0.1.2"}}}),
+        }
+
+    def __call__(self, url, *, token=None):
+        self.calls.append(url)
+        path = urlsplit(url).path
+        if path.endswith("/commits/main"):
+            key = "main"
+        elif path.endswith("/contents/pyproject.toml"):
+            key = "source"
+        elif path.endswith("/contents/src/fantasy_football_manager/mcp_server.py"):
+            key = "tools"
+        elif path.endswith("/actions/workflows/ci.yml/runs"):
+            key = "ci"
+        elif path.endswith("/releases"):
+            key = "releases"
+        elif url.startswith("https://pypi.org/"):
+            key = "pypi"
+        elif url == distribution.GLAMA + "/tree":
+            key = "tree"
+        elif url == distribution.GLAMA + "/schema":
+            key = "schema"
+        elif url == distribution.GLAMA:
+            key = "overview"
+        else:
+            raise AssertionError("Unexpected public endpoint.")
+        if key in self.failures:
+            raise self.failures[key]
+        value = self.responses[key]
+        return value if isinstance(value, str) else json.dumps(value)
+
+
+@pytest.fixture
+def public_reader(monkeypatch):
+    def git_value(*args):
+        if args == ("rev-parse", "HEAD"):
+            return HEAD
+        if args == ("status", "--porcelain"):
+            return ""
+        raise AssertionError("Unexpected git query.")
+    monkeypatch.setattr(distribution, "git_value", git_value)
+    return PublicReader()
+
+
+def test_hydration_decodes_data_without_executing_page_scripts():
+    value = {"loaderData": {"fictional": {"text": "<script>raise Exception('never run')</script>",
+             "tools": ["one", "two"], "count": 2, "enabled": True, "missing": None}}}
+    html = hydration(value)
+    assert distribution.decode_hydration(html) == value
+    assert distribution.decode_hydration(hydration_nodes([{ "_1": -5 }, "missing"])) == {"missing": None}
+
+
+@pytest.mark.parametrize("nodes", [[], {}, [{"bad-key": 1}, "value"], [[0]], [[True]], [[999]],
+                                   [{"_1": 2, "_3": 2}, "same", "value", "same"],
+                                   [{"_1": 2}, 7, "value"], [[-1]]])
+def test_invalid_hydration_references_and_cycles_are_rejected(nodes):
+    with pytest.raises(distribution.CheckError):
+        distribution.decode_hydration(hydration_nodes(nodes))
+
+
+def test_hydration_depth_and_chunk_count_are_bounded():
+    nodes = [[i + 1] for i in range(102)] + ["leaf"]
+    with pytest.raises(distribution.CheckError):
+        distribution.decode_hydration(hydration_nodes(nodes))
+    page = hydration({"ok": True})
+    with pytest.raises(distribution.CheckError):
+        distribution.decode_hydration(page + page)
+    with pytest.raises(distribution.CheckError):
+        distribution.decode_hydration("<html>No compatible hydration.</html>")
+
+
+def test_matching_public_sources_do_not_attest_a_hosted_build(public_reader):
+    report = distribution.collect(reader=public_reader)
+    checks = report["checks"]
+    assert checks["github_main"]["commit"] == HEAD
+    assert checks["github_ci"]["status"] == "current"
+    assert checks["glama_index"]["status"] == "current"
+    assert checks["glama_tools"]["expected_count"] == 17
+    assert checks["glama_tools"]["public_count"] == 17
+    assert checks["glama_build"]["status"] == "unknown"
+    assert report["status"] == "attention"
+    assert report["attention"] == ["glama_build"]
+    assert checks["glama_listing"]["status"] == "observed"
+    assert checks["glama_listing"]["image_release"] == "0.1.2"
+    assert report["read_only"] is True and report["remote_writes"] == 0 and report["model_calls"] == 0
+    for url in public_reader.calls:
+        if "/contents/" in url:
+            assert parse_qs(urlsplit(url).query)["ref"] == [HEAD]
+    ci_url = next(url for url in public_reader.calls if "/actions/workflows/" in url)
+    assert parse_qs(urlsplit(ci_url).query)["head_sha"] == [HEAD]
+
+
+@pytest.mark.parametrize("endpoint,check", [("ci", "github_ci"), ("releases", "github_release"),
+    ("pypi", "pypi_release"), ("tree", "glama_index"), ("schema", "glama_tools"),
+    ("overview", "glama_listing"), ("tools", "glama_tools"), ("source", "source_package")])
+def test_upstream_failures_stay_unknown_and_preserve_independent_checks(public_reader, endpoint, check):
+    public_reader.failures[endpoint] = distribution.CheckError(SECRET)
+    report = distribution.collect(reader=public_reader, token=SECRET)
+    assert report["checks"][check]["status"] == "unknown"
+    assert report["checks"]["github_main"]["status"] == "current"
+    if endpoint != "tree":
+        assert report["checks"]["glama_index"]["status"] == "current"
+    if endpoint == "source":
+        assert report["checks"]["github_release"]["status"] == "unknown"
+        assert report["checks"]["pypi_release"]["status"] == "unknown"
+    assert SECRET not in json.dumps(report) + distribution.markdown(report)
+    assert report["status"] == "attention"
+
+
+def test_glama_index_compares_exact_remote_main_not_local_head(public_reader, monkeypatch):
+    monkeypatch.setattr(distribution, "git_value", lambda *args: OLD_HEAD if args[0] == "rev-parse" else "")
+    public_reader.responses["tree"] = route_page("_explorer/tree/_index/_route", {"member": {"commit": {"sha": OLD_HEAD}}})
+    report = distribution.collect(reader=public_reader)
+    assert report["checks"]["local_checkout"]["status"] == "pending"
+    assert report["checks"]["glama_index"]["status"] == "stale"
+    assert report["checks"]["glama_index"]["expected_commit"] == HEAD
+    assert report["checks"]["glama_index"]["indexed_commit"] == OLD_HEAD
+
+
+def test_changed_or_duplicate_public_metadata_does_not_report_current(public_reader):
+    tools = [{"name": f"manager_tool_{i}", "description": f"Read fictional manager data {i}."} for i in range(17)]
+    tools[0]["description"] = "Old documentation."
+    tools.append({"name": "list_managed_teams", "description": "Portfolio data belongs to a separate server."})
+    public_reader.responses["schema"] = route_page("schema/_route", {"schema": {"tools": tools}})
+    report = distribution.collect(reader=public_reader)
+    result = report["checks"]["glama_tools"]
+    assert result["status"] == "stale" and result["expected_count"] == 17
+    assert result["changed_descriptions"] == ["manager_tool_0"]
+    assert result["unexpected"] == ["list_managed_teams"]
+    assert "portfolio tools are not compared" in result["scope"]
+    tools.append(deepcopy(tools[0]))
+    public_reader.responses["schema"] = route_page("schema/_route", {"schema": {"tools": tools}})
+    assert distribution.collect(reader=public_reader)["checks"]["glama_tools"]["status"] == "unknown"
+
+
+@pytest.mark.parametrize("runs,expected", [
+    ([], "pending"),
+    ([ci_run(head=OLD_HEAD)], "pending"),
+    ([ci_run(branch="feature")], "pending"),
+    ([ci_run(event="pull_request")], "pending"),
+    ([ci_run(status="in_progress", conclusion=None)], "pending"),
+    ([ci_run(conclusion="failure")], "failed"),
+    ([ci_run(conclusion="cancelled")], "failed"),
+    ([ci_run(event="workflow_dispatch")], "current"),
+    ([ci_run(), ci_run(run_id=11, status="queued", conclusion=None)], "pending"),
+    ([ci_run(run_id=12, conclusion="failure"), ci_run(run_id=11)], "failed"),
+    ([ci_run(), ci_run(head=OLD_HEAD, run_id=99, conclusion="failure")], "current"),
+])
+def test_ci_uses_latest_matching_main_run_and_preserves_failure_states(runs, expected):
+    assert distribution.ci_status({"workflow_runs": runs}, HEAD)["status"] == expected
+
+
+@pytest.mark.parametrize("response", [None, [], {"unexpected": []}, {"workflow_runs": None}, {"workflow_runs": ["invalid"]}])
+def test_malformed_ci_data_is_unknown_in_public_report(public_reader, response):
+    public_reader.responses["ci"] = response
+    assert distribution.collect(reader=public_reader)["checks"]["github_ci"]["status"] == "unknown"
+
+
+@pytest.mark.parametrize("version", ["123", "true", '""'])
+def test_invalid_source_version_is_unknown(public_reader, version):
+    public_reader.responses["source"] = encoded_content("[project]\nversion=" + version + "\n")
+    checks = distribution.collect(reader=public_reader)["checks"]
+    assert checks["source_package"]["status"] == "unknown"
+    assert checks["github_release"]["status"] == "unknown"
+    assert checks["pypi_release"]["status"] == "unknown"
+
+
+def test_wrong_public_shapes_cannot_turn_green(public_reader):
+    public_reader.responses["tree"] = hydration(["not a route mapping"])
+    public_reader.responses["schema"] = route_page("schema/_route", {"schema": {"tools": {"unexpected": "mapping"}}})
+    public_reader.responses["overview"] = hydration(None)
+    public_reader.responses["pypi"] = {"info": {"name": "some-other-package", "version": VERSION}}
+    public_reader.responses["releases"] = {"unexpected": "mapping"}
+    checks = distribution.collect(reader=public_reader)["checks"]
+    for check in ("glama_index", "glama_tools", "glama_listing", "pypi_release", "github_release"):
+        assert checks[check]["status"] == "unknown"
+
+
+def test_source_tool_inspection_never_imports_or_executes_source():
+    source = 'raise RuntimeError("Do not execute source")\n' + manager_source()
+    tools = distribution.source_tools(source)
+    assert len(tools) == 17
+    assert tools["manager_tool_0"] == "Read fictional manager data 0."
+
+
+class Response:
+    def __init__(self, body=b"{}", error=None):
+        self.body, self.error = body, error
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def read(self, size):
+        if self.error is not None:
+            raise self.error
+        return self.body[:size]
+
+
+def fake_opener(monkeypatch, response=None, error=None):
+    captured = []
+    class Opener:
+        def open(self, request, *, timeout):
+            captured.append(request)
+            if error is not None:
+                raise error
+            return response or Response()
+    def factory(handler):
+        assert isinstance(handler, distribution.NoRedirect)
+        return Opener()
+    monkeypatch.setattr(distribution, "build_opener", factory)
+    return captured
+
+
+def test_token_is_sent_only_to_the_fixed_github_host(monkeypatch):
+    requests = fake_opener(monkeypatch)
+    for url in (distribution.GITHUB + "/commits/main", distribution.GLAMA, "https://pypi.org/pypi/fantasy-football-manager/json"):
+        assert distribution.fetch(url, token=SECRET) == "{}"
+    assert requests[0].get_header("Authorization") == "Bearer " + SECRET
+    assert all(request.get_header("Authorization") is None for request in requests[1:])
+
+
+@pytest.mark.parametrize("url", ["http://api.github.com/repos/x", "https://evil.example/", "https://api.github.com.evil.example/",
+                                 "https://api.github.com@evil.example/", "https://user:password@api.github.com/",
+                                 "https://api.github.com:444/", "file:///private/secret", "https://glama.ai@evil.example/"])
+def test_untrusted_endpoints_are_rejected_before_a_request(url):
+    with pytest.raises(distribution.CheckError, match="unexpected_endpoint"):
+        distribution.fetch(url, token=SECRET)
+
+
+def test_redirect_cannot_forward_a_github_token():
+    request = Request(distribution.GITHUB, headers={"Authorization": "Bearer " + SECRET})
+    with pytest.raises(distribution.CheckError, match="redirect_refused"):
+        distribution.NoRedirect().redirect_request(request, None, 302, "Found", {}, "https://evil.example/")
+
+
+@pytest.mark.parametrize("failure", [URLError(SECRET), TimeoutError(SECRET), OSError(SECRET),
+                                     HTTPError("https://api.github.com/", 403, SECRET, {}, None)])
+def test_transport_errors_do_not_expose_tokens(monkeypatch, failure):
+    fake_opener(monkeypatch, error=failure)
+    with pytest.raises(distribution.CheckError) as error:
+        distribution.fetch(distribution.GITHUB, token=SECRET)
+    assert SECRET not in str(error.value)
+
+
+@pytest.mark.parametrize("failure", [IncompleteRead(b"private-response", 30), BadStatusLine(SECRET)])
+def test_broken_http_stream_is_a_safe_unknown_failure(monkeypatch, failure):
+    fake_opener(monkeypatch, response=Response(error=failure))
+    with pytest.raises(distribution.CheckError) as error:
+        distribution.fetch(distribution.GITHUB, token=SECRET)
+    assert SECRET not in str(error.value) and "private-response" not in str(error.value)
+
+
+def test_oversized_and_invalid_utf8_responses_are_rejected(monkeypatch):
+    fake_opener(monkeypatch, response=Response(b"x" * (distribution.MAX_BYTES + 1)))
+    with pytest.raises(distribution.CheckError, match="response_too_large"):
+        distribution.fetch(distribution.GLAMA)
+    fake_opener(monkeypatch, response=Response(b"\xff"))
+    with pytest.raises(distribution.CheckError, match="request_failed"):
+        distribution.fetch(distribution.GLAMA)
+
+
+@pytest.mark.parametrize("strict,overall,exit_code", [(False, "attention", 0), (True, "attention", 1), (True, "current", 0)])
+def test_cli_exit_status_does_not_confuse_collection_with_readiness(tmp_path, monkeypatch, capsys, strict, overall, exit_code):
+    report = {"checked_at": AT, "status": overall, "checks": {"github_ci": {"status": "pending" if overall == "attention" else "current"}},
+              "read_only": True, "remote_writes": 0, "model_calls": 0}
+    monkeypatch.setattr(distribution, "collect", lambda **kwargs: report)
+    output, summary = tmp_path / "report.json", tmp_path / "summary.md"
+    arguments = ["check_distribution_status", "--output", str(output), "--summary", str(summary)]
+    if strict:
+        arguments.append("--strict")
+    monkeypatch.setattr("sys.argv", arguments)
+    assert distribution.main() == exit_code
+    assert json.loads(output.read_text())["status"] == overall
+    assert "does not mean every service is current" in summary.read_text()
+    assert json.loads(capsys.readouterr().out)["status"] == overall
+
+
+def test_failed_main_lookup_produces_unknown_report_and_exit_two(tmp_path, monkeypatch, capsys):
+    def fail(**kwargs):
+        raise distribution.CheckError(SECRET)
+    monkeypatch.setattr(distribution, "collect", fail)
+    monkeypatch.setenv("GH_TOKEN", SECRET)
+    output, summary = tmp_path / "report.json", tmp_path / "summary.md"
+    monkeypatch.setattr("sys.argv", ["check_distribution_status", "--output", str(output), "--summary", str(summary)])
+    assert distribution.main() == 2
+    text = output.read_text() + summary.read_text() + capsys.readouterr().out
+    assert SECRET not in text
+    assert json.loads(output.read_text())["status"] == "unknown"
+
+
+def test_github_actions_flags_incomplete_evidence(tmp_path, monkeypatch, capsys):
+    report = {"checked_at": AT, "status": "attention", "checks": {"glama_index": {"status": "stale"}}}
+    monkeypatch.setattr(distribution, "collect", lambda **kwargs: report)
+    monkeypatch.setenv("GITHUB_ACTIONS", "true")
+    monkeypatch.setattr("sys.argv", ["check_distribution_status", "--output", str(tmp_path / "report.json"),
+                                    "--summary", str(tmp_path / "summary.md")])
+    assert distribution.main() == 0
+    lines = capsys.readouterr().out.splitlines()
+    assert json.loads(lines[0])["checks"]["glama_index"] == "stale"
+    assert lines[1].startswith("::warning title=FF distribution needs review::")
+
+
+@pytest.mark.parametrize("malformed", [[], None, "not a commit object"])
+def test_malformed_main_replaces_prior_green_report_with_fresh_unknown(tmp_path, monkeypatch, public_reader, malformed):
+    public_reader.responses["main"] = malformed
+    collect = distribution.collect
+    monkeypatch.setattr(distribution, "collect", lambda **kwargs: collect(reader=public_reader, **kwargs))
+    output, summary = tmp_path / "report.json", tmp_path / "summary.md"
+    output.write_text(json.dumps({"status": "current", "checks": {"github_main": {"status": "current"}}}), encoding="utf-8")
+    summary.write_text("Overall: current", encoding="utf-8")
+    monkeypatch.setattr("sys.argv", ["check_distribution_status", "--output", str(output), "--summary", str(summary)])
+    assert distribution.main() == 2
+    report = json.loads(output.read_text())
+    assert report["status"] == "unknown"
+    assert report["checks"]["github_main"]["status"] == "unknown"
+    assert "Overall: **unknown**" in summary.read_text()
+    assert report["read_only"] is True and report["remote_writes"] == 0
+    assert len(public_reader.calls) == 1
+
+
+def test_markdown_escapes_remote_table_and_html_content():
+    report = {"checked_at": AT, "status": "attention", "checks": {"fictional": {
+        "status": "unknown", "detail": "<img src=x onerror=bad()> | `code`\nnext"}}}
+    result = distribution.markdown(report)
+    assert "<img" not in result and "`code`" not in result
+    assert "&lt;img" in result and "&#124;" in result and "&#96;code&#96;" in result


### PR DESCRIPTION
GitHub source updates did not establish whether Glama had indexed the same commit. Add a repository-only distribution check that reports the exact gap after updates.

The workflow runs on main pushes, completed main CI, published releases, manual requests, and a daily schedule. It compares the checkout and GitHub main, checks CI and release versions, and reads Glama's indexed source commit and manager tool descriptions. Each run saves a report and flags pending, stale, failed, or unknown evidence.

The checker uses read-only HTTP requests and no model calls. It cannot verify the deployed Glama build commit from the observed public pages. That result remains unknown. The workflow does not publish packages, request a sync, or trigger a build.

Project instructions require the report before the final update handoff. No global Codex settings or other projects change.

Validation: focused parser, response-failure, metadata, CI, authentication-boundary, and CLI tests; release privacy checks; a live read that found Glama's indexed source behind GitHub while manager descriptions matched. The new workflow still requires its first run after merge.
