### PR TITLE
Prepare v0.4.0 preview for public release

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fantasy-football-manager",
   "version": "0.4.0",
-  "description": "ESPN season transactions, draft tools, and a multi-team portfolio dashboard for Codex. Version 0.4.0 release candidate.",
+  "description": "ESPN season transactions, draft tools, and a multi-team portfolio dashboard for Codex. Version 0.4.0 preview.",
   "author": {
     "name": "krmisystems",
     "url": "https://github.com/krmisystems"
@@ -14,7 +14,7 @@
     "brandColor": "#14251F",
     "displayName": "Fantasy Football Manager",
     "shortDescription": "Inspect all teams and manage ESPN actions within saved limits.",
-    "longDescription": "The v0.4.0 release candidate adds HTTP season transactions, a five-tool portfolio MCP, and a localhost dashboard. Inspect configured teams, players, analysis, and proposals. Optional dashboard controls approve exact saved HTTP season proposals through the existing transaction service. Saved modes and limits apply. Draft operation retains its browser adapter. This candidate is not yet published. A live trial verified automatic free-agent add/drop and a subsequent lineup exchange. Live dashboard submissions, waiver processing, IR moves, scoring-week rollover, and an unattended season remain Not Tested. Football is the only implemented sport. Trade execution is unavailable.",
+    "longDescription": "The v0.4.0 preview adds HTTP season transactions, a five-tool portfolio MCP, and a localhost dashboard. Inspect configured teams, players, analysis, and proposals. Optional dashboard controls approve exact saved HTTP season proposals through the existing transaction service. Saved modes and limits apply. Draft operation retains its browser adapter. A live trial verified automatic free-agent add/drop and a subsequent lineup exchange. Live dashboard submissions, waiver processing, IR moves, scoring-week rollover, and an unattended season remain Not Tested. Football is the only implemented sport. Trade execution is unavailable.",
     "developerName": "krmisystems",
     "category": "Productivity",
     "capabilities": [

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ The **portfolio MCP** adds five tools for all configured teams, players, saved p
 HTTP season actions include lineups, free-agent additions, waiver claims, drops, and IR moves.
 Draft support retains the existing browser adapter.
 
-**Release candidate:** The reviewed v0.4.0 wheel is deployed privately and has completed a five-team HTTP observation sweep.
+**Version 0.4.0 preview:** The reviewed v0.4.0 wheel is deployed privately and has completed a five-team HTTP observation sweep.
 An explicitly authorized coverage repair also confirmed two automatic HTTP actions: a free-agent add/drop and a subsequent lineup exchange.
-Public release remains incomplete. Public v0.3.3 assets retain their earlier behavior.
+Version 0.3.3 assets retain their earlier behavior. See the release links below for the v0.4.0 preview.
 Read [HTTP season acceptance](docs/HTTP_SEASON_ACCEPTANCE.md) for the current evidence and remaining live validation.
 
 This independent project requires your ESPN account. A protected session file supplies HTTP authentication.
@@ -27,7 +27,7 @@ Run this demo with Python 3.11 or later and [uv](https://docs.astral.sh/uv/).
 It requires no ESPN account, Chrome session, or MCP client.
 
 ```sh
-uvx --from fantasy-football-manager==0.3.3 fantasy-football-manager --demo
+uvx --from fantasy-football-manager==0.4.0 fantasy-football-manager --demo
 ```
 
 The command prints a fictional lineup report and exits without changing saved league state.
@@ -201,6 +201,10 @@ Five-team season outcomes and uninterrupted season operation remain [unverified]
 
 ## Install from PyPI
 
+Version 0.4.0 adds HTTP season transactions, the portfolio MCP, and the Fieldroom dashboard.
+The base HTTP installation needs no browser. Install the `browser` extra for live drafts.
+
+
 Version 0.3.3 expands the descriptions, input schemas, and behavior annotations for all 30 MCP tools.
 Read the [tool definition review](docs/TOOL_DEFINITION_QUALITY.md) for compatibility checks and external scoring status.
 Version 0.3.2 preserves verified opponent draft history when a season projection is missing.
@@ -212,9 +216,11 @@ Use Python 3.11 or later and [uv](https://docs.astral.sh/uv/).
 The published v0.3.3 browser workflow also requires installed Google Chrome.
 
 ```sh
-uv tool install fantasy-football-manager
+uv tool install fantasy-football-manager==0.4.0
 fantasy-football-manager --help
 fantasy-football-espn --help
+fantasy-football-portfolio --help
+fantasy-football-dashboard --help
 ```
 
 ## Install from source
@@ -226,6 +232,8 @@ uv sync --locked --dev
 uv tool install --force .
 fantasy-football-manager --help
 fantasy-football-espn --help
+fantasy-football-portfolio --help
+fantasy-football-dashboard --help
 ```
 
 ## Connect the commands
@@ -249,9 +257,9 @@ Use `FFM_BROWSER_DATA_DIR` to select a shared browser profile root across separa
 Browser mode accepts an optional `cdp_url` for an explicit loopback browser debugging endpoint.
 Keep profiles, credentials, databases, logs, and real league exports outside Git. Read the [privacy notes](https://github.com/krmisystems/fantasy-football-manager/blob/main/docs/PRIVACY.md).
 
-Use the [v0.3.3 release page](https://github.com/krmisystems/fantasy-football-manager/releases/tag/v0.3.3) for the versioned
-[wheel](https://github.com/krmisystems/fantasy-football-manager/releases/download/v0.3.3/fantasy_football_manager-0.3.3-py3-none-any.whl),
-[plugin ZIP](https://github.com/krmisystems/fantasy-football-manager/releases/download/v0.3.3/fantasy-football-manager-0.3.3-plugin.zip), and checksums.
+Use the [v0.4.0 release page](https://github.com/krmisystems/fantasy-football-manager/releases/tag/v0.4.0) for the versioned
+[wheel](https://github.com/krmisystems/fantasy-football-manager/releases/download/v0.4.0/fantasy_football_manager-0.4.0-py3-none-any.whl),
+[plugin ZIP](https://github.com/krmisystems/fantasy-football-manager/releases/download/v0.4.0/fantasy-football-manager-0.4.0-plugin.zip), and checksums.
 The [distribution acceptance record](https://github.com/krmisystems/fantasy-football-manager/blob/main/docs/DISCOVERY_ACCEPTANCE.md) tracks verified GitHub, PyPI, and MCP Registry publication separately.
 Follow the [release instructions](https://github.com/krmisystems/fantasy-football-manager/blob/main/docs/RELEASING.md) for publisher setup. Earlier published assets remain unchanged.
 
@@ -270,7 +278,7 @@ The v0.4.0 local suite passed **1,048 tests with 22 skips**. A separate PostgreS
 A fresh base installation passed actual STDIO checks for 17 manager tools and 16 ESPN tools without Playwright.
 All 28 deployed Python files matched the reviewed wheel. Existing dependency versions and team policies remained unchanged.
 One authorized repair subsequently verified automatic HTTP add/drop and lineup execution in a single Week 1 context.
-Live waiver processing, IR moves, and scoring-week rollover remain Not Tested. Public release remains incomplete.
+Live waiver processing, IR moves, and scoring-week rollover remain Not Tested.
 Read [HTTP season acceptance](docs/HTTP_SEASON_ACCEPTANCE.md) for the exact evidence boundary.
 
 The v0.3.3 source passed **664 tests across the base and separate Chrome runs**, including **17 isolated Chrome cases**.

--- a/docs/CATALOG_PLUGIN.md
+++ b/docs/CATALOG_PLUGIN.md
@@ -31,6 +31,6 @@ The distribution workflow accepts completed main-branch runs through its trigger
 It also checks the source repository and event type, then checks out the fixed `refs/heads/main` ref.
 It never selects a checkout ref from an incoming workflow payload.
 
-The source plugin remains an unreleased v0.4.0 candidate.
+The plugin uses the v0.4.0 preview commands.
 A catalog submission or scanner pass does not publish the Python package or update Glama.
 Use the [distribution check](DISTRIBUTION_STATUS.md) to verify those channels separately.

--- a/docs/PLUGIN_INSTALL.md
+++ b/docs/PLUGIN_INSTALL.md
@@ -4,7 +4,7 @@ The source plugin adds four workflow skills and three local MCP servers.
 It uses `fantasy-football-manager`, `fantasy-football-espn`, and `fantasy-football-portfolio`.
 The portfolio adds five read-only tools across explicitly configured team stores.
 Configure `FFM_PORTFOLIO_MANIFEST` for that command. See the [portfolio guide](PORTFOLIO.md).
-The unreleased v0.4.0 candidate exposes 16 ESPN tools, including HTTP season transactions without a browser runtime.
+The v0.4.0 preview exposes 16 ESPN tools, including HTTP season transactions without a browser runtime.
 Draft operation retains the browser adapter. Trade execution remains unavailable.
 The published v0.3.3 package has the original 13 ESPN tools and browser lineup workflow.
 Do not assume that installing the published package supplies the new HTTP tools.
@@ -23,12 +23,12 @@ The plugin archive contains registrations and skills. Install the Python wheel s
 Install the published commands:
 
 ```sh
-uv tool install fantasy-football-manager
+uv tool install fantasy-football-manager==0.4.0
 fantasy-football-manager --help
 fantasy-football-espn --help
 ```
 
-For the unreleased HTTP implementation, use the [source installation](../README.md#install-from-source).
+For a development build, use the [source installation](../README.md#install-from-source).
 Run these commands from the repository root to install both optional workflows:
 
 ```sh
@@ -40,14 +40,14 @@ The base HTTP runtime requires neither Chrome nor Playwright.
 The `browser` extra supplies Playwright for draft and legacy season operation. Those workflows also require installed Google Chrome.
 The `session-import` extra supplies cryptography for the optional Linux session importer.
 An already provisioned HTTP session file does not require that extra.
-Configure source commands through the checkout environment until a release includes this implementation.
+Use the v0.4.0 commands or configure a source checkout environment.
 
 Check that the Codex process can find the configured commands on `PATH`.
 Restart Codex if you changed its environment.
 The manager and ESPN servers must share a per-team data directory.
 The portfolio reads all directories listed in its private manifest.
 
-## Configure an HTTP season session (unreleased)
+## Configure an HTTP season session (v0.4.0)
 
 Use an existing authorized ESPN session. The HTTP adapter does not provide password sign-in or renew expired sessions.
 Store only `SWID` and `espn_s2` in a protected local JSON file.
@@ -193,7 +193,7 @@ Run the printed `codex plugin add` command.
 Start a new Codex conversation.
 Ask Codex to call `get_capabilities` and `espn_get_status`.
 Use the synthetic workflow to check the manager without a real league.
-Use the HTTP session setup above for season operation from the unreleased source checkout.
+Use the HTTP session setup above for season operation with v0.4.0.
 For a browser draft, use `espn_connect` in draft phase and complete sign-in in the dedicated profile.
 See the [ESPN workflow](ESPN_AUTOMATION.md) before enabling automatic submissions.
 
@@ -204,7 +204,7 @@ Use either this plugin or direct MCP registrations to avoid duplicate tool sets.
 ## Inspect the source
 
 - [Plugin manifest](../plugins/fantasy-football-manager/.codex-plugin/plugin.json)
-- [Both MCP commands](../plugins/fantasy-football-manager/.mcp.json)
+- [Three MCP commands](../plugins/fantasy-football-manager/.mcp.json)
 - [Draft skill](../plugins/fantasy-football-manager/skills/draft-assistant/SKILL.md)
 - [ESPN automation skill](../plugins/fantasy-football-manager/skills/espn-automation/SKILL.md)
 - [Season skill](../plugins/fantasy-football-manager/skills/season-manager/SKILL.md)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -138,7 +138,7 @@ uv run python scripts/build_plugin_zip.py
 
 Twine checks the selected Python distributions only.
 The ZIP builder writes a plugin archive and a SHA-256 manifest to `dist/`.
-The archive includes three skills and registrations for both installed MCP commands.
+The archive includes four skills and registrations for three installed MCP commands.
 It copies an explicit list of plugin files. It does not include league records or local state.
 
 Inspect the wheel, source distribution, and plugin manifest before publication.
@@ -211,8 +211,8 @@ Record the installed package, private launchers, and interventions with each liv
 Isolated Chrome fixture tests verify browser mechanics without changing a real league.
 Earlier direct browser picks do not establish packaged selector compatibility.
 Distinguish implemented lineup automation from live acceptance testing.
-The v0.4.0 candidate implements HTTP season lineups, waivers, acquisitions, drops, IR moves, and automatic week rollover.
+The v0.4.0 preview implements HTTP season lineups, waivers, acquisitions, drops, IR moves, and automatic week rollover.
 Its privately deployed wheel has five-team read acceptance and one verified automatic free-agent add/drop and lineup repair.
-Live waiver processing, IR moves, and scoring-week rollover remain Not Tested. Public release remains incomplete.
+Live waiver processing, IR moves, and scoring-week rollover remain Not Tested.
 Read [HTTP season acceptance](HTTP_SEASON_ACCEPTANCE.md) for package verification and remaining gates.
 Trade execution remains outside the release scope.

--- a/docs/VALIDATION.md
+++ b/docs/VALIDATION.md
@@ -2,7 +2,7 @@
 
 Read the [September 10 systems review](SYSTEM_REVIEW.md) for the latest startup correction, deployment checks, and remaining delivery gates.
 
-## Version 0.4.0 HTTP season candidate
+## Version 0.4.0 HTTP season preview
 
 Read [HTTP season acceptance](HTTP_SEASON_ACCEPTANCE.md) for current source tests, authenticated reads, and live transaction evidence.
 The candidate adds HTTP lineups, acquisitions, IR moves, automatic period rollover, and incremental archive export.
@@ -12,7 +12,7 @@ A fresh base installation passed both MCP servers without Playwright.
 The deployed HTTP coordinator completed a five-team sweep with accurate analysis readiness.
 One authorized repair verified automatic HTTP free-agent add/drop and a subsequent lineup exchange.
 Both transactions matched ESPN receipts and fresh roster observations. A follow-up cycle confirmed no duplicate submission.
-Live waiver processing, IR moves, rollover, and an unattended season remain Not Tested. Public release remains incomplete.
+Live waiver processing, IR moves, rollover, and an unattended season remain Not Tested.
 The results below describe their original versions and do not establish acceptance of this candidate.
 
 ## Earlier release evidence

--- a/plugins/fantasy-football-manager/.codex-plugin/plugin.json
+++ b/plugins/fantasy-football-manager/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fantasy-football-manager",
   "version": "0.4.0",
-  "description": "ESPN season transactions, draft tools, and a multi-team portfolio dashboard for Codex. Version 0.4.0 release candidate.",
+  "description": "ESPN season transactions, draft tools, and a multi-team portfolio dashboard for Codex. Version 0.4.0 preview.",
   "author": {
     "name": "krmisystems",
     "url": "https://github.com/krmisystems"
@@ -14,7 +14,7 @@
     "brandColor": "#14251F",
     "displayName": "Fantasy Football Manager",
     "shortDescription": "Inspect all teams and manage ESPN actions within saved limits.",
-    "longDescription": "The v0.4.0 release candidate adds HTTP season transactions, a five-tool portfolio MCP, and a localhost dashboard. Inspect configured teams, players, analysis, and proposals. Optional dashboard controls approve exact saved HTTP season proposals through the existing transaction service. Saved modes and limits apply. Draft operation retains its browser adapter. This candidate is not yet published. A live trial verified automatic free-agent add/drop and a subsequent lineup exchange. Live dashboard submissions, waiver processing, IR moves, scoring-week rollover, and an unattended season remain Not Tested. Football is the only implemented sport. Trade execution is unavailable.",
+    "longDescription": "The v0.4.0 preview adds HTTP season transactions, a five-tool portfolio MCP, and a localhost dashboard. Inspect configured teams, players, analysis, and proposals. Optional dashboard controls approve exact saved HTTP season proposals through the existing transaction service. Saved modes and limits apply. Draft operation retains its browser adapter. A live trial verified automatic free-agent add/drop and a subsequent lineup exchange. Live dashboard submissions, waiver processing, IR moves, scoring-week rollover, and an unattended season remain Not Tested. Football is the only implemented sport. Trade execution is unavailable.",
     "developerName": "krmisystems",
     "category": "Productivity",
     "capabilities": [

--- a/plugins/fantasy-football-manager/README.md
+++ b/plugins/fantasy-football-manager/README.md
@@ -4,18 +4,18 @@ This plugin registers four skills and three local MCP servers for ESPN fantasy f
 It supports draft analysis, season proposals, and a portfolio of configured teams.
 Saved automation modes and per-team limits control submissions.
 
-This source package is the **unreleased v0.4.0 candidate**.
+This source package is the **v0.4.0 preview**.
 The published v0.3.3 Python package does not contain all of these tools.
-Install the candidate commands from the source checkout:
+Install the matching Python commands:
 
 ```sh
-uv tool install .
+uv tool install fantasy-football-manager==0.4.0
 fantasy-football-manager --help
 fantasy-football-espn --help
 fantasy-football-portfolio --help
 ```
 
-Run the installation command from the cloned repository root, not this plugin directory.
+For a source build, run `uv tool install .` from the cloned repository root.
 Make the three commands available on the Codex process's `PATH`.
 Configure private team stores, the portfolio manifest, and authorized ESPN sessions separately.
 The plugin contains registrations and instructions. It does not contain the Python runtime or credentials.


### PR DESCRIPTION
Prepare the reviewed v0.4.0 candidate for public preview distribution. Update installation commands and download links to the exact version. Replace pending-publication wording in packaged metadata while retaining the live validation limits.

Runtime source is byte-identical to reviewed commit `1105be07cd88b0d1202cde92f246ed89fec864f9`. No ESPN actions or policy changes are part of this preparation.

Validation: all 50 release tests passed; release metadata/privacy checks passed for 188 files; root and standalone Codex plugin validators passed. The release workflow will test and package the exact release commit before publication.
