### PR TITLE
Address Hashgraph scanner findings and verify artifact downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,8 +138,9 @@ jobs:
           uv run python - <<'PY'
           from pathlib import Path
           import hashlib
-          original = {p.name: hashlib.sha256(p.read_bytes()).hexdigest() for p in Path("dist").iterdir() if p.is_file()}
-          downloaded = {p.name: hashlib.sha256(p.read_bytes()).hexdigest() for p in Path("downloaded-artifacts").iterdir() if p.is_file()}
+          # uv build creates a hidden .gitignore; artifact uploads exclude hidden files.
+          original = {p.name: hashlib.sha256(p.read_bytes()).hexdigest() for p in Path("dist").iterdir() if p.is_file() and not p.name.startswith(".")}
+          downloaded = {p.name: hashlib.sha256(p.read_bytes()).hexdigest() for p in Path("downloaded-artifacts").iterdir() if p.is_file() and not p.name.startswith(".")}
           assert len(original) == 4, "Expected the wheel, source archive, plugin archive, and plugin manifest"
           assert original == downloaded, "Downloaded release artifacts differ from the package job outputs"
           print("Verified all four artifact downloads against package job outputs.")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,3 +128,19 @@ jobs:
           name: distribution-files
           path: dist/
           if-no-files-found: error
+      - name: Download the packaged release artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: distribution-files
+          path: downloaded-artifacts/
+      - name: Verify downloaded release artifacts
+        run: |
+          uv run python - <<'PY'
+          from pathlib import Path
+          import hashlib
+          original = {p.name: hashlib.sha256(p.read_bytes()).hexdigest() for p in Path("dist").iterdir() if p.is_file()}
+          downloaded = {p.name: hashlib.sha256(p.read_bytes()).hexdigest() for p in Path("downloaded-artifacts").iterdir() if p.is_file()}
+          assert len(original) == 4, "Expected the wheel, source archive, plugin archive, and plugin manifest"
+          assert original == downloaded, "Downloaded release artifacts differ from the package job outputs"
+          print("Verified all four artifact downloads against package job outputs.")
+          PY

--- a/docs/HOL_SCANNER_REVIEW.md
+++ b/docs/HOL_SCANNER_REVIEW.md
@@ -1,0 +1,49 @@
+﻿# HOL scanner review
+
+This review addresses the maintainer request on [catalog PR 411](https://github.com/hashgraph-online/awesome-codex-plugins/pull/411).
+All results below are static checks. They do not verify live ESPN execution.
+
+## Reproduction and correction
+
+The earlier catalog job used `plugin-scanner==2.0.1116` and `cisco-ai-skill-scanner==2.0.14`.
+A local reproduction against source commit `1105be07cd88b0d1202cde92f246ed89fec864f9` returned the same score and finding counts.
+Both reported **97/100**, with **14 informational findings** and no critical, high, medium, or low findings.
+Read the [original catalog job](https://github.com/hashgraph-online/awesome-codex-plugins/actions/runs/34544280506/job/103093464463).
+
+The repository contains a canonical plugin and a generated repository-root mirror.
+Each layout contains four skills. The scanner reports findings for both layouts.
+The correction adds `license: MIT` to each skill and regenerates the mirror.
+The license matches the existing repository and plugin licenses.
+It also corrects outdated publication wording in three skills. Version 0.4.0 is now a published preview.
+
+## Rule dispositions
+
+| Rule | Earlier count | Current count | Disposition |
+| --- | ---: | ---: | --- |
+| `MANIFEST_MISSING_LICENSE` | 8 | 0 | Fixed. All four canonical skills and all four mirrored skills declare MIT. |
+| `PLUGIN_JSON_INTERFACE_ASSET_TERMSOFSERVICEURL` | 2 | 2 | Documented omission. The optional field is absent. The project supplies its MIT license and privacy policy. No separate terms URL is claimed. |
+| `PLUGIN_JSON_INTERFACE_ASSET_LOGO` | 2 | 2 | Documented omission. The optional field is absent. Both layouts declare a valid `composerIcon` asset. |
+| `PLUGIN_JSON_INTERFACE_ASSET_SCREENSHOTS` | 2 | 2 | Documented omission. The optional field is absent. Public screenshots remain in the README and portfolio documentation. |
+
+The six remaining findings concern absent optional fields. They do not identify unsafe URLs or missing declared assets.
+The review retains these fields as omitted. It does not add placeholder URLs, suppress rules, or lower the scan threshold.
+
+## Verified follow-up
+
+On September 11, 2026, the corrected source passed these local checks:
+
+- Scanner **3.0.153**, with Cisco skill scanner **2.0.14**, returned **97/100**, grade A, and six informational findings.
+- Cisco skill scanning used the balanced policy with `static_analyzer`, `bytecode`, and `pipeline`. It returned zero findings.
+- Scanner **3.0.151**, the version pinned in source CI, returned **97/100**, grade A, and the same six native findings.
+- All 50 release validation tests passed.
+- Root and canonical skill files match through the catalog generator.
+
+The scanner 3.0.153 wheel matched the digest published in the catalog contribution guide:
+`24ef86abac32db5b8ca2f73e84fa76c46fd758c95d74d1cd5d1e1a73f4e8cdb1`.
+
+The [source scanner workflow](../.github/workflows/hol-plugin-scanner.yml) retains its reviewed action SHA, minimum score 80, and high-severity failure threshold.
+The supplemental local scan uses the current catalog guide version. It does not replace or weaken source CI.
+Cisco MCP scanning was unavailable. The scanner 3.0.151 local environment also lacked Cisco skill scanning.
+These limits are separate from the completed Cisco skill check under scanner 3.0.153.
+
+The published v0.4.0 artifacts retain their original bytes. These source skill corrections do not replace an existing release asset.

--- a/plugins/fantasy-football-manager/skills/draft-assistant/SKILL.md
+++ b/plugins/fantasy-football-manager/skills/draft-assistant/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: draft-assistant
 description: Compare legal draft candidates and run continuous simulations with the manager MCP. Route live ESPN draft requests to the included ESPN companion workflow.
+license: MIT
 ---
 
 # Draft assistant
@@ -10,7 +11,7 @@ Read `get_capabilities` and `get_manager_config` before selecting the workflow.
 For a real ESPN draft, use the included `espn-automation` skill and its companion tools.
 The manager's `execute_demo_action` tool is for synthetic state only.
 
-The v0.4.0 release candidate preserves the browser draft adapter. It is not yet a published release.
+The published v0.4.0 preview preserves the browser draft adapter.
 The source `browser` extra and installed Chrome are required for that adapter.
 Its new HTTP transport applies to season operation and does not replace draft submission.
 Use `season-manager` after an explicit season connection. Completing a draft does not authorize new season action modes.

--- a/plugins/fantasy-football-manager/skills/espn-automation/SKILL.md
+++ b/plugins/fantasy-football-manager/skills/espn-automation/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: espn-automation
 description: Connect the ESPN companion for browser drafts or HTTP season operation. Run continuous analysis and submit exact transactions within saved user limits.
+license: MIT
 ---
 
 # ESPN automation
@@ -8,8 +9,8 @@ description: Connect the ESPN companion for browser drafts or HTTP season operat
 Use the `fantasy-football-espn` companion supplied by this plugin for live ESPN drafts.
 Use `season-manager` for HTTP lineups, acquisitions, waiver claims, drops, and IR through the same companion.
 Use the manager MCP for saved configuration and strategy.
-The v0.4.0 release candidate adds HTTP season operation and exposes 16 ESPN tools. It is not yet published.
-The published v0.3.3 companion retains 13 tools, browser drafts, and one-swap lineup proposals.
+The published v0.4.0 preview adds HTTP season operation and exposes 16 ESPN tools.
+Version 0.3.3 retains 13 ESPN tools, browser drafts, and one-swap lineup proposals.
 Check the current release evidence before claiming live account acceptance.
 Distinguish installed-package checks, authenticated reads, live submissions, and fictional HTTP or browser tests.
 Trade execution remains unavailable.

--- a/plugins/fantasy-football-manager/skills/portfolio-manager/SKILL.md
+++ b/plugins/fantasy-football-manager/skills/portfolio-manager/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: portfolio-manager
 description: Inspect all configured fantasy teams, saved players, lineup analysis, and transaction proposals through the portfolio MCP. Open the local dashboard for visual review and exact proposal approval.
+license: MIT
 ---
 
 # Portfolio manager

--- a/plugins/fantasy-football-manager/skills/season-manager/SKILL.md
+++ b/plugins/fantasy-football-manager/skills/season-manager/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: season-manager
 description: Manage ESPN season lineups, acquisitions, waiver claims, and IR through authenticated HTTP. Preserve user limits and reconcile every transaction.
+license: MIT
 ---
 
 # Season manager
 
 Read `get_capabilities` and `get_manager_config` before selecting a season workflow.
 Read `espn_get_status` and discover the installed companion tools.
-The v0.4.0 release candidate supplies 16 ESPN tools and HTTP season operation. It is not yet a published release.
-The published v0.3.3 companion has 13 tools and browser lineup swaps.
+The published v0.4.0 preview supplies 16 ESPN tools and HTTP season operation.
+Version 0.3.3 has 13 ESPN tools and browser lineup swaps.
 Use the installed version's capabilities. Do not infer a live write from source code or fictional tests.
 The manager provides weekly analysis and synthetic execution. The ESPN companion owns real submissions.
 Trade execution remains unavailable.

--- a/skills/draft-assistant/SKILL.md
+++ b/skills/draft-assistant/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: draft-assistant
 description: Compare legal draft candidates and run continuous simulations with the manager MCP. Route live ESPN draft requests to the included ESPN companion workflow.
+license: MIT
 ---
 
 # Draft assistant
@@ -10,7 +11,7 @@ Read `get_capabilities` and `get_manager_config` before selecting the workflow.
 For a real ESPN draft, use the included `espn-automation` skill and its companion tools.
 The manager's `execute_demo_action` tool is for synthetic state only.
 
-The v0.4.0 release candidate preserves the browser draft adapter. It is not yet a published release.
+The published v0.4.0 preview preserves the browser draft adapter.
 The source `browser` extra and installed Chrome are required for that adapter.
 Its new HTTP transport applies to season operation and does not replace draft submission.
 Use `season-manager` after an explicit season connection. Completing a draft does not authorize new season action modes.

--- a/skills/espn-automation/SKILL.md
+++ b/skills/espn-automation/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: espn-automation
 description: Connect the ESPN companion for browser drafts or HTTP season operation. Run continuous analysis and submit exact transactions within saved user limits.
+license: MIT
 ---
 
 # ESPN automation
@@ -8,8 +9,8 @@ description: Connect the ESPN companion for browser drafts or HTTP season operat
 Use the `fantasy-football-espn` companion supplied by this plugin for live ESPN drafts.
 Use `season-manager` for HTTP lineups, acquisitions, waiver claims, drops, and IR through the same companion.
 Use the manager MCP for saved configuration and strategy.
-The v0.4.0 release candidate adds HTTP season operation and exposes 16 ESPN tools. It is not yet published.
-The published v0.3.3 companion retains 13 tools, browser drafts, and one-swap lineup proposals.
+The published v0.4.0 preview adds HTTP season operation and exposes 16 ESPN tools.
+Version 0.3.3 retains 13 ESPN tools, browser drafts, and one-swap lineup proposals.
 Check the current release evidence before claiming live account acceptance.
 Distinguish installed-package checks, authenticated reads, live submissions, and fictional HTTP or browser tests.
 Trade execution remains unavailable.

--- a/skills/portfolio-manager/SKILL.md
+++ b/skills/portfolio-manager/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: portfolio-manager
 description: Inspect all configured fantasy teams, saved players, lineup analysis, and transaction proposals through the portfolio MCP. Open the local dashboard for visual review and exact proposal approval.
+license: MIT
 ---
 
 # Portfolio manager

--- a/skills/season-manager/SKILL.md
+++ b/skills/season-manager/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: season-manager
 description: Manage ESPN season lineups, acquisitions, waiver claims, and IR through authenticated HTTP. Preserve user limits and reconcile every transaction.
+license: MIT
 ---
 
 # Season manager
 
 Read `get_capabilities` and `get_manager_config` before selecting a season workflow.
 Read `espn_get_status` and discover the installed companion tools.
-The v0.4.0 release candidate supplies 16 ESPN tools and HTTP season operation. It is not yet a published release.
-The published v0.3.3 companion has 13 tools and browser lineup swaps.
+The published v0.4.0 preview supplies 16 ESPN tools and HTTP season operation.
+Version 0.3.3 has 13 ESPN tools and browser lineup swaps.
 Use the installed version's capabilities. Do not infer a live write from source code or fictional tests.
 The manager provides weekly analysis and synthetic execution. The ESPN companion owns real submissions.
 Trade execution remains unavailable.


### PR DESCRIPTION
Address the Hashgraph maintainer review with explicit MIT license fields in all four canonical skills and their generated mirrors. Correct outdated v0.4.0 publication wording. Document all 14 original scanner findings and the six remaining optional-field omissions in `docs/HOL_SCANNER_REVIEW.md`.

The reproduced original scan used 2.0.1116 with Cisco skill scanner 2.0.14. The corrected source passes scanner 3.0.153 with six informational findings and zero Cisco skill findings. The source CI scanner pin and thresholds remain unchanged.

Add a package CI download step using the reviewed download-artifact v8 pin. Compare the four downloaded files against the package job hashes. This exercises the merged upload-artifact v7 and download-artifact v8 actions together without publishing a package.

Validation: 50 release tests passed. Release metadata/privacy checks and catalog mirror checks passed. No runtime Python code, live team state, or existing release assets changed.
